### PR TITLE
Improved: Applied custom sorting to bring brokering queue, pre-order parking and, backorder parking first in the list. Also changed view entity used.

### DIFF
--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -440,10 +440,11 @@ const actions: ActionTree<FacilityState, RootState> = {
     try {
       const params = {
         inputFields: {
-          parentTypeId: "VIRTUAL_FACILITY"
+          parentFacilityTypeId: "VIRTUAL_FACILITY"
         },
         orderBy: "facilityName ASC",
-        entityName: "FacilityAndType",
+        entityName: "FacilityAndProductStore",
+        fieldList: ["facilityId", "facilityName", "description", "facilityTypeId", "parentFacilityTypeId"],
         viewSize: 100
       }
 
@@ -458,6 +459,14 @@ const actions: ActionTree<FacilityState, RootState> = {
     } catch(error) {
       logger.error(error)
     }
+
+    //Applying custom sorting to alwyas bring Brokering queue, Pre-order parking and backorder parking first.
+    const customOrder = ['BACKORDER_PARKING', 'PRE_ORDER_PARKING', '_NA_'];
+    facilities.sort((firstFacility:any, secondFacility:any) => {
+      const firstFacilityOrder = customOrder.indexOf(firstFacility.facilityId);
+      const secondFacilityOrder = customOrder.indexOf(secondFacility.facilityId);
+      return secondFacilityOrder - firstFacilityOrder;
+    });
     
     commit(types.FACILITY_VIRTUAL_FACILITY_LIST_UPDATED , { facilities, total });
     if (facilities.length) {

--- a/src/views/Parking.vue
+++ b/src/views/Parking.vue
@@ -109,7 +109,7 @@ export default defineComponent({
 <style scoped>
 .virtual-facilities {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
   align-items: start; 
 }
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Improved: Applied custom sorting to bring brokering queue, pre-order parking and, backorder parking first in the list. Also changed view entity used.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)