### PR TITLE
Improved: code to show 'Not scheduled' when no brokering job is scheduled (#87)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -174,6 +174,7 @@
   "No product stores added.": "No product stores added.",
   "No records found": "No records found",
   "No time zone found": "No time zone found",
+  "Not scheduled": "Not scheduled",
   "OMS": "OMS",
   "OMS instance": "OMS instance",
   "Online Order Fulfillment": "Online Order Fulfillment",

--- a/src/views/Parking.vue
+++ b/src/views/Parking.vue
@@ -33,7 +33,7 @@
                 </ion-item>
                 <ion-item lines="full">
                   <ion-label>{{ translate('Next brokering') }}</ion-label>
-                  <ion-note slot="end">{{ facility?.brokeringJob?.runTime ? getDateTime(facility?.brokeringJob?.runTime) : '-' }}</ion-note>
+                  <ion-note slot="end">{{ facility?.brokeringJob?.runTime ? getDateTime(facility?.brokeringJob?.runTime) : translate("Not scheduled") }}</ion-note>
                 </ion-item>
               </template>
               <ion-item v-else>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #87

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved code to show 'Not scheduled' instead of '-' if not brokering job is scheduled.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2023-12-11 11-14-38](https://github.com/hotwax/facilities/assets/69574321/7ed71f37-bda9-496c-92dd-a187d74d1234)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)