### PR TITLE
Improved: UI to display a block level add button on the product store card when no stores are linked to the facility(#96)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -179,7 +179,6 @@
   "No fulfillment capacity": "No fulfillment capacity",
   "No groups found": "No groups found",
   "No party found": "No party found",
-  "No product stores added.": "No product stores added.",
   "No records found": "No records found",
   "No time zone found": "No time zone found",
   "Not scheduled": "Not scheduled",

--- a/src/views/AddFacilityConfig.vue
+++ b/src/views/AddFacilityConfig.vue
@@ -13,7 +13,7 @@
             <ion-card-title>
               {{ translate("Product Stores") }}
             </ion-card-title>
-            <ion-button @click="selectProductStore()" fill="clear">
+            <ion-button v-if="selectedProductStores.length" @click="selectProductStore()" fill="clear">
               <ion-icon :icon="addCircleOutline" slot="start" />
               {{ translate("Add") }}
             </ion-button>
@@ -50,9 +50,10 @@
               </ion-item>
             </ion-list>
           </template>
-          <div v-else class="empty-state">
-            <p>{{ translate("No product stores added.") }}</p>
-          </div>
+          <ion-button v-else expand="block" fill="outline" @click="selectProductStore()">
+            {{ translate("Add") }}
+            <ion-icon slot="end" :icon="addCircleOutline" />
+          </ion-button>
         </ion-card>
 
         <ion-card>

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -137,7 +137,7 @@
               <ion-card-title>
                 {{ translate("Product Stores") }}
               </ion-card-title>
-              <ion-button @click="selectProductStores()" fill="clear">
+              <ion-button v-if="facilityProductStores.length" @click="selectProductStores()" fill="clear">
                 <ion-icon :icon="addCircleOutline" slot="end" />
                 {{ translate("Add") }}
               </ion-button>
@@ -149,6 +149,10 @@
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>
             </ion-item>
+            <ion-button v-if="!facilityProductStores.length" expand="block" fill="outline" @click="selectProductStores()">
+              {{ translate("Add") }}
+              <ion-icon slot="end" :icon="addCircleOutline" />
+            </ion-button>
           </ion-card>
         </section>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #96

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before:

![image](https://github.com/hotwax/facilities/assets/41404838/1dc4b613-5ae2-4a5b-a29a-017286e4c192)


After:

![image](https://github.com/hotwax/facilities/assets/41404838/7667f48a-7ad8-42e6-977d-ff77c39838be)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)