### PR TITLE
Fixed: sell online inventory toggle on find facilities page where due to the incorrect group association information toggle was not working correctly (#129).

### DIFF
--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -298,9 +298,11 @@ export default defineComponent({
 
         if (!hasError(resp)) {
           // updating the facilities state instead of refetching
+          const facilityGroupInformation = await FacilityService.fetchFacilityGroupInformation([facility.facilityId]);
           const updatedFacilities = JSON.parse(JSON.stringify(this.facilities)).map((facilityData: any) => {
             if (facility.facilityId === facilityData.facilityId) {
               facilityData.sellOnline = !facility.sellOnline
+              facilityData.groupInformation = facilityGroupInformation[facility.facilityId]
             }
             return facilityData
           })


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #129 

### Short Description and Why It's Useful
Fixed: sell online inventory toggle on find facilities page where due to the incorrect group association information toggle was not working correctly (#129).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)