### PR TITLE
Improved: facility group UI to redirect the user to find facilities page with the group filter applied when clicking on facilities item (#141).

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -161,6 +161,7 @@
   "Generate shipping labels": "Generate shipping labels",
   "Go to Launchpad": "Go to Launchpad",
   "Go to OMS": "Go to OMS",
+  "Group": "Group",
   "Group associated to system group types.": "Group associated to system group types.",
   "Group unlinked from facility": "Group unlinked from facility",
   "Groups": "Groups",

--- a/src/store/modules/facility/FacilityState.ts
+++ b/src/store/modules/facility/FacilityState.ts
@@ -2,7 +2,8 @@ export default interface FacilityState {
   facilityQuery: {
     queryString: string,
     productStoreId: string,
-    facilityTypeId: string
+    facilityTypeId: string,
+    facilityGroupId: string
   },
   groupQuery: {
     queryString: string

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -79,16 +79,31 @@ const actions: ActionTree<FacilityState, RootState> = {
       filters['facilityName_value'] = state.facilityQuery.queryString
       filters['facilityName_op'] = 'contains'
       filters['facilityName_ic'] = 'Y'
-      filters['facilityName_grp'] = '2'
+      filters['facilityName_grp'] = '1'
+      filters['grp_op_1'] = 'OR'
+    }
+
+    if (state.facilityQuery.facilityGroupId) {
+      filters['facilityGroupId'] = state.facilityQuery.facilityGroupId
+      filters['facilityGroupId_op'] = 'equals'
+      filters['facilityGroupId_grp'] = '2'
+      filters['primaryFacilityGroupId'] = state.facilityQuery.facilityGroupId
+      filters['primaryFacilityGroupId_op'] = 'equals'
+      filters['primaryFacilityGroupId_grp'] = '2'
+      filters['grp_op_2'] = 'OR'
     }
 
     const params = {
       "inputFields": {
+        "grp_op": "AND",
         ...filters
       },
-      "entityName": "FacilityAndProductStore",
+      "entityName": "FacilityView",
       "noConditionFind": "Y",
       "distinct": "Y",
+      "fromDateName": "facilityGroupFromDate",
+      "thruDateName": "facilityGroupThruDate",
+      "filterByDate": "Y",
       "fieldList": ['facilityId', 'facilityName', 'facilityTypeId', 'maximumOrderLimit', 'defaultDaysToShip', 'externalId', 'primaryFacilityGroupId', 'parentFacilityTypeId'],
       ...payload
     }

--- a/src/store/modules/facility/index.ts
+++ b/src/store/modules/facility/index.ts
@@ -11,7 +11,8 @@ const facilityModule: Module<FacilityState, RootState> = {
     facilityQuery: {
       queryString: '',
       productStoreId: '',
-      facilityTypeId: ''
+      facilityTypeId: '',
+      facilityGroupId: ''
     },
     groupQuery: {
       queryString: ''

--- a/src/views/FindGroups.vue
+++ b/src/views/FindGroups.vue
@@ -41,7 +41,7 @@
                 <ion-icon :icon="ellipsisVerticalOutline" slot="icon-only"/>
               </ion-button>
             </ion-item>
-            <ion-item>
+            <ion-item @click="viewFacilities(group.facilityGroupId)" button>
               <ion-label>{{ translate('Facilities') }}</ion-label>
               <ion-note slot="end">{{ group.facilityCount }}</ion-note>
             </ion-item>
@@ -143,6 +143,7 @@ export default defineComponent({
       facilityGroupTypes: "util/getFacilityGroupTypes",
       isScrollable: "facility/isFacilityGroupsScrollable",
       query: "facility/getGroupQuery",
+      facilityQuery: "facility/getFacilityQuery",
     })
   },
   async mounted() {
@@ -153,6 +154,10 @@ export default defineComponent({
     async updateQuery() {
       await this.store.dispatch('facility/updateGroupQuery', this.query)
       this.fetchGroups();
+    },
+    async viewFacilities(facilityGroupId: string) {
+      await this.store.dispatch('facility/updateFacilityQuery', {...this.facilityQuery, facilityGroupId })
+      this.$router.push({ path: `/find-facilities`})
     },
     async fetchGroups(vSize?: any, vIndex?: any) {
       const viewSize = vSize ? vSize : process.env.VUE_APP_VIEW_SIZE;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Improved: facility group UI to redirect the user to find facilities page with the group filter applied when clicking on facilities item (#141).


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)