### PR TITLE
Improved: Text overlapping in facility view page(#173)

### DIFF
--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -60,7 +60,7 @@
               <ion-label class="ion-text-wrap">
                 <p class="overline">{{ facility.facilityTypeId ? facilityTypes[facility.facilityTypeId] ? facilityTypes[facility.facilityTypeId].description : facilityTypes.facilityTypeId : '' }}</p>
                 {{ facility.facilityName }}
-                <p class="ion-text-wrap">{{ facility.facilityId }}</p>
+                <p>{{ facility.facilityId }}</p>
               </ion-label>
             </ion-item>
 

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -57,10 +57,10 @@
           <div class="list-item" v-for="(facility, index) in facilities" :key="index" @click="viewFacilityDetails(facility.facilityId)">
             <ion-item lines="none">
               <ion-icon slot="start" :icon="facilityTypes[facility.facilityTypeId]?.parentTypeId === 'DISTRIBUTION_CENTER' ? businessOutline : storefrontOutline" />
-              <ion-label>
+              <ion-label class="ion-text-wrap">
                 <p class="overline">{{ facility.facilityTypeId ? facilityTypes[facility.facilityTypeId] ? facilityTypes[facility.facilityTypeId].description : facilityTypes.facilityTypeId : '' }}</p>
                 {{ facility.facilityName }}
-                <p>{{ facility.facilityId }}</p>
+                <p class="ion-text-wrap">{{ facility.facilityId }}</p>
               </ion-label>
             </ion-item>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #173

### Short D
Removed the text overlapping issue which is enhancing readability in facility details page by moving the text in next line when screen size is getting small.

description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
It is necessary because when user will open the facility page in small screen size , the text was overlapping with "sell online" button. So, It enhances the user experience.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-01-16 12-37-07](https://github.com/hotwax/facilities/assets/83332530/14e28df3-4d14-4d38-9cba-cec542c03c7c)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)