### PR TITLE
Fixed: inventory channel groups not showing until page refresh (#169)

### DIFF
--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -185,6 +185,7 @@ const actions: ActionTree<FacilityState, RootState> = {
       // As inventory channels are fetched while fetching additional facility info
       // But here we already have additional facility info, so just getting and adding inventory groups to current.
       const inventoryGroups = rootGetters['util/getInventoryGroups'];
+      // Creating a key called 'isChecked' for inventory groups already associated with current facility.
       inventoryGroups.forEach((group: any) => {
         const isChecked = (current.facilityGroupInfo?.some((facilityGroup: any) => facilityGroup?.facilityGroupId === group.facilityGroupId))
         group.isChecked = isChecked ? isChecked : false;

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -177,13 +177,20 @@ const actions: ActionTree<FacilityState, RootState> = {
     commit(types.FACILITY_CURRENT_UPDATED, facility)
   },
 
-  async fetchCurrentFacility({ commit, dispatch, state }, payload) {
+  async fetchCurrentFacility({ commit, dispatch, rootGetters, state }, payload) {
     // checking that if the list contains basic information for facility then not fetching the same information again
     const cachedFacilities = JSON.parse(JSON.stringify(state.facilities.list))
     const current = cachedFacilities.find((facility: any) => facility.facilityId === payload.facilityId)
     if(current?.facilityId && !payload.skipState) {
+      // As inventory channels are fetched while fetching additional facility info
+      // But here we already have additional facility info, so just getting and adding inventory groups to current.
+      const inventoryGroups = rootGetters['util/getInventoryGroups'];
+      inventoryGroups.forEach((group: any) => {
+        const isChecked = (current.facilityGroupInfo?.some((facilityGroup: any) => facilityGroup?.facilityGroupId === group.facilityGroupId))
+        group.isChecked = isChecked ? isChecked : false;
+      });
+      current.inventoryGroups = inventoryGroups;
       commit(types.FACILITY_CURRENT_UPDATED, current);
-      await dispatch('fetchFacilityAdditionalInformation', payload);
       return;
     }
 

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -183,6 +183,7 @@ const actions: ActionTree<FacilityState, RootState> = {
     const current = cachedFacilities.find((facility: any) => facility.facilityId === payload.facilityId)
     if(current?.facilityId && !payload.skipState) {
       commit(types.FACILITY_CURRENT_UPDATED, current);
+      await dispatch('fetchFacilityAdditionalInformation', payload);
       return;
     }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #169

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed issue of inventory channel groups not showing until page refersh in facility details page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)