### PR TITLE
Improved: toast message to show server message in case of failure in create facility(#196)

### DIFF
--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -188,9 +188,9 @@ export default defineComponent({
         } else {
           throw resp.data;
         }
-      } catch (error) {
+      } catch (error: any) {
         logger.error(error)
-        showToast(translate('Failed to create facility.'))
+        showToast(translate(error.response.data.error?.message))
         return;
       }
 

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -190,7 +190,7 @@ export default defineComponent({
         }
       } catch (error: any) {
         logger.error(error)
-        showToast(translate(error.response.data.error?.message))
+        showToast(error.response.data.error?.message)
         return;
       }
 

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -190,8 +190,8 @@ export default defineComponent({
         }
       } catch (error: any) {
         logger.error(error)
-        if(error.response.data.error?.message) {
-          showToast(error?.response?.data?.error?.message)
+        if(error?.response?.data?.error?.message) {
+          showToast(error.response.data.error.message)
         } else {
           showToast(translate('Failed to create facility.'))
         }

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -190,7 +190,11 @@ export default defineComponent({
         }
       } catch (error: any) {
         logger.error(error)
-        showToast(error.response.data.error?.message)
+        if(error.response.data.error?.message) {
+          showToast(error?.response?.data?.error?.message)
+        } else {
+          showToast(translate('Failed to create facility.'))
+        }
         return;
       }
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #196

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved code to dynamically display server message in the toast message in case create facility api fails due to duplicate facility id.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)