### PR TITLE
fixed: all not showing up by default in find facilities filters (#202)

### DIFF
--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -299,7 +299,8 @@ const actions: ActionTree<FacilityState, RootState> = {
     commit(types.FACILITY_QUERY_UPDATED, {
       queryString: '',
       productStoreId: '',
-      facilityTypeId: ''
+      facilityTypeId: '',
+      facilityGroupId: ''
     })
     commit(types.FACILITY_GROUP_QUERY_UPDATED, {
       queryString: '',


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Closes #202

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
All was not showing up by default in find facilites because of missing entry in clearQueryState. Hence added the missing key for facilityGroupId filter to fix it.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)