### PR TITLE
Improved: logic to redirect to login page with users partyId and login credentials for opening current session in users app (user-107)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@ VUE_APP_PERMISSION_ID="FACILITIES_APP_VIEW"
 VUE_APP_LOCALES={"en-US": "English"}
 VUE_APP_DEFAULT_LOG_LEVEL="error"
 VUE_APP_LOGIN_URL="http://launchpad.hotwax.io/login"
-VUE_APP_USERS_APPLICATION_URL="http://users.hotwax.io"
+VUE_APP_USERS_LOGIN_URL="http://users.hotwax.io/login"

--- a/src/components/FacilityLoginActionPopover.vue
+++ b/src/components/FacilityLoginActionPopover.vue
@@ -53,7 +53,7 @@ export default defineComponent({
   props: ['currentFacility', 'currentFacilityUser', "facilityTypeDesc"],
   methods: {
     async viewDetails() {
-      const userDetailUrl = `${process.env.VUE_APP_USERS_APPLICATION_URL}/login/?oms=${this.authStore.oms}&token=${this.authStore.token.value}&expirationTime=${this.authStore.token.expiration}&partyId=${this.currentFacilityUser.partyId}`
+      const userDetailUrl = `${process.env.VUE_APP_USERS_LOGIN_URL}?oms=${this.authStore.oms}&token=${this.authStore.token.value}&expirationTime=${this.authStore.token.expiration}&partyId=${this.currentFacilityUser.partyId}`
       window.location.href = userDetailUrl
       popoverController.dismiss()
     },

--- a/src/components/FacilityLoginActionPopover.vue
+++ b/src/components/FacilityLoginActionPopover.vue
@@ -53,7 +53,7 @@ export default defineComponent({
   props: ['currentFacility', 'currentFacilityUser', "facilityTypeDesc"],
   methods: {
     async viewDetails() {
-      const userDetailUrl = `${process.env.VUE_APP_USERS_APPLICATION_URL}?oms=${this.authStore.oms}&token=${this.authStore.token.value}&expirationTime=${this.authStore.token.expiration}&partyId=${this.currentFacilityUser.partyId}`
+      const userDetailUrl = `${process.env.VUE_APP_USERS_APPLICATION_URL}/login/?oms=${this.authStore.oms}&token=${this.authStore.token.value}&expirationTime=${this.authStore.token.expiration}&partyId=${this.currentFacilityUser.partyId}`
       window.location.href = userDetailUrl
       popoverController.dismiss()
     },

--- a/src/components/FacilityLoginActionPopover.vue
+++ b/src/components/FacilityLoginActionPopover.vue
@@ -39,6 +39,7 @@ import { hasError } from "@/adapter";
 import { showToast } from "@/utils";
 import logger from "@/logger";
 import emitter from "@/event-bus";
+import { useAuthStore } from '@hotwax/dxp-components'
 
 export default defineComponent({
   name: "ProductStorePopover",
@@ -52,7 +53,7 @@ export default defineComponent({
   props: ['currentFacility', 'currentFacilityUser', "facilityTypeDesc"],
   methods: {
     async viewDetails() {
-      const userDetailUrl = `${process.env.VUE_APP_USERS_APPLICATION_URL}/user-details/${this.currentFacilityUser.partyId}`
+      const userDetailUrl = `${process.env.VUE_APP_USERS_APPLICATION_URL}?oms=${this.authStore.oms}&token=${this.authStore.token.value}&expirationTime=${this.authStore.token.expiration}&partyId=${this.currentFacilityUser.partyId}`
       window.location.href = userDetailUrl
       popoverController.dismiss()
     },
@@ -193,8 +194,10 @@ export default defineComponent({
   },
   setup() {
     const store = useStore();
+    const authStore = useAuthStore()
 
     return {
+      authStore,
       removeCircleOutline,
       keyOutline,
       mailOutline,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue: https://github.com/hotwax/user-management/issues/107

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Redirecting to users login route with oms, token and partyId such that current session is used in users app when redirecting from facilities to users.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)