### PR TITLE
Improved: removed the back button from the tab pages (#215)

### DIFF
--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -4,7 +4,6 @@
 
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" default-href="/" />
         <ion-title>{{ translate("Find Facilities") }}</ion-title>
         <ion-buttons slot="end" class="mobile-only">
           <ion-menu-button menu="end">
@@ -126,7 +125,6 @@
 
 <script lang="ts">
 import {
-  IonBackButton,
   IonButtons,
   IonChip,
   IonContent,
@@ -177,7 +175,6 @@ export default defineComponent({
   name: 'FindFacilities',
   components: {
     FacilityFilters,
-    IonBackButton,
     IonButtons,
     IonChip,
     IonContent,

--- a/src/views/FindGroups.vue
+++ b/src/views/FindGroups.vue
@@ -2,7 +2,6 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" default-href="/" />
         <ion-title>{{ translate("Groups") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -87,7 +86,6 @@
 <script lang="ts">
 import {
   IonButton,
-  IonBackButton,
   IonBadge,
   IonCard,
   IonChip,
@@ -130,7 +128,6 @@ export default defineComponent({
   name: 'FindGroups',
   components: {
     IonButton,
-    IonBackButton,
     IonBadge,
     IonCard,
     IonChip,

--- a/src/views/Parking.vue
+++ b/src/views/Parking.vue
@@ -2,7 +2,6 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
-        <ion-back-button slot="start" default-href="/"/>
         <ion-title>{{ translate("Parking") }}</ion-title>
         <ion-buttons slot="end">
           <ion-button @click="openArchivedFacilityModal()">
@@ -69,7 +68,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import {
-  IonBackButton,
   IonButton,
   IonButtons,
   IonCard,
@@ -105,7 +103,6 @@ import logger from "@/logger";
 export default defineComponent({
   name: 'Parking',
   components: {
-    IonBackButton,
     IonButton,
     IonButtons,
     IonCard,

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -2,7 +2,6 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" default-href="/" />
         <ion-title>{{ translate("Settings") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -71,7 +70,6 @@
 <script lang="ts">
 import { 
   IonAvatar,
-  IonBackButton,
   IonButton, 
   IonCard, 
   IonCardContent,
@@ -102,7 +100,6 @@ export default defineComponent({
   name: 'Settings',
   components: {
     IonAvatar,
-    IonBackButton,
     IonButton,
     IonCard,
     IonCardContent,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #215

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed the ion-back-button from the pages which opens up using tab navigation.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before 
![Screenshot from 2024-03-08 12-39-17](https://github.com/hotwax/facilities/assets/69574321/17447d47-6190-41cd-b96c-c4ef49aa3d54)

After
![Screenshot from 2024-03-08 12-39-10](https://github.com/hotwax/facilities/assets/69574321/afa7864e-9a37-4f23-92bb-644d07adee0b)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)