### PR TITLE
Implemented: support to allow user to set shipping name for facility address (#154)

### DIFF
--- a/src/components/FacilityAddressModal.vue
+++ b/src/components/FacilityAddressModal.vue
@@ -16,6 +16,10 @@
         <ion-label>{{ translate("Address") }}</ion-label>
       </ion-item-divider>
       <ion-item>
+        <ion-label position="floating">{{ translate("Shipping name") }}</ion-label>
+        <ion-input v-model="address.toName" />
+      </ion-item>
+      <ion-item>
         <ion-label position="floating">{{ translate("Address line 1") }} <ion-text color="danger">*</ion-text></ion-label>
         <ion-input v-model="address.address1" />
       </ion-item>
@@ -128,7 +132,7 @@ export default defineComponent({
       telecomNumberValue: {} as any
     }
   },
-  props: ['facilityId'],
+  props: ['facilityId', 'facilityName'],
   beforeMount() {
     this.address = JSON.parse(JSON.stringify(this.postalAddress))
     this.telecomNumberValue = this.telecomNumber ? JSON.parse(JSON.stringify(this.telecomNumber)) : {}
@@ -138,6 +142,9 @@ export default defineComponent({
     if(this.address.countryGeoId) {
       const country = this.countries.find((country: any) => country.geoId === this.address.countryGeoId)
       this.telecomNumberValue.countryCode = getTelecomCountryCode(country.geoCode)
+    }
+    if(!this.address.toName) {
+      this.address.toName = this.facilityName
     }
   },
   methods: {
@@ -243,3 +250,9 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+ion-content {
+  --padding-bottom: 80px;
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -324,6 +324,7 @@
   "Settings": "Settings",
   "Setting fulfillment capacity to 0 disables new order from being allocated to this facility. Leave this empty if this facility's fulfillment capacity is unrestricted.": "Setting fulfillment capacity to 0 disables new order from being allocated to this facility. Leave this empty if this facility's fulfillment capacity is unrestricted.",
   "Setup Store": "Setup Store",
+  "Shipping name": "Shipping name",
   "Shopify": "Shopify",
   "Shopify facility": "Shopify facility",
   "Shopify location": "Shopify location",

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -237,7 +237,7 @@ const actions: ActionTree<FacilityState, RootState> = {
       entityName: "FacilityContactDetailByPurpose",
       orderBy: 'fromDate DESC',
       filterByDate: 'Y',
-      fieldList: ['address1', 'address2', 'city', 'contactMechId', 'countryGeoId', 'countryGeoName', 'latitude', 'longitude', 'postalCode', 'stateGeoId', 'stateGeoName'],
+      fieldList: ['address1', 'address2', 'city', 'contactMechId', 'countryGeoId', 'countryGeoName', 'latitude', 'longitude', 'postalCode', 'stateGeoId', 'stateGeoName', 'toName'],
       viewSize: 1
     }
 

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -192,7 +192,7 @@ export default defineComponent({
   },
   props: ['facilityId'],
   async ionViewWillEnter() {
-    this.formData.toName = this.current.facilityName
+    this.formData.toName = this.current?.facilityName ? this.current.facilityName : ''
     await this.store.dispatch('util/fetchCountries', { countryGeoId: "USA" })
   },
   methods: {

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -15,6 +15,12 @@
           <ion-list>
             <ion-item>
               <ion-label position="floating">
+                {{ translate('Shipping name') }}
+              </ion-label>
+              <ion-input v-model="formData.toName" />
+            </ion-item>
+            <ion-item>
+              <ion-label position="floating">
                 {{ translate('Address line 1') }} <ion-text color="danger">*</ion-text>
               </ion-label>
               <ion-input v-model="formData.address1" />
@@ -163,12 +169,14 @@ export default defineComponent({
   computed: {
     ...mapGetters({
       countries: 'util/getCountries',
-      states: 'util/getStates'
+      states: 'util/getStates',
+      current: 'facility/getCurrent',
     })
   },
   data() {
     return {
       formData: {
+        toName: '',
         address1: '',
         address2: '',
         city: '',
@@ -184,6 +192,7 @@ export default defineComponent({
   },
   props: ['facilityId'],
   async ionViewWillEnter() {
+    this.formData.toName = this.current.facilityName
     await this.store.dispatch('util/fetchCountries', { countryGeoId: "USA" })
   },
   methods: {

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -184,6 +184,7 @@ export default defineComponent({
         if (!hasError(resp)) {
           const { facilityId } = resp.data
           showToast(translate("Facility created successfully."))
+          this.store.dispatch('facility/updateCurrentFacility', payload),
           this.router.replace(`/add-facility-address/${facilityId}`)
         } else {
           throw resp.data;

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -50,6 +50,7 @@
               <template v-if="postalAddress?.address1">
                 <ion-item lines="full">
                   <ion-label>
+                    <h3>{{ postalAddress.toName }}</h3>
                     <h3>{{ postalAddress.address1 }}</h3>
                     <h3>{{ postalAddress.address2 }}</h3>
                     <p class="ion-text-wrap">{{ postalAddress.postalCode ? `${postalAddress.city}, ${postalAddress.postalCode}` : postalAddress.city }}</p>
@@ -739,7 +740,7 @@ export default defineComponent({
     async openAddressModal() {
       const addressModal = await modalController.create({
         component: FacilityAddressModal,
-        componentProps: { facilityId: this.facilityId }
+        componentProps: { facilityId: this.facilityId, facilityName: this.current.facilityName }
       })
 
       addressModal.onDidDismiss().then(async(result) => {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #154

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added fields to add shipping name while setting facility postal address. Also displayed shipping name in the address and contact details card in facility details page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-03-11 17-56-13](https://github.com/hotwax/facilities/assets/69574321/76645be0-44ec-4aa9-9b35-3eef136e4df9)
![Screenshot from 2024-03-11 17-55-43](https://github.com/hotwax/facilities/assets/69574321/89009329-12c7-4e79-9552-4d319da5feba)
![Screenshot from 2024-03-11 17-56-02](https://github.com/hotwax/facilities/assets/69574321/e65cb1a1-baf4-4861-8848-5dbec67919d1)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)