### PR TITLE
Fixed: all facilities not showing up in select facilities modal in facility group card. (#220)

### DIFF
--- a/src/components/AddFacilityToGroupModal.vue
+++ b/src/components/AddFacilityToGroupModal.vue
@@ -122,13 +122,10 @@ export default defineComponent({
         "inputFields": {
           ...filters
         },
-        "entityName": "FacilityView",
+        "entityName": "Facility",
         "noConditionFind": "Y",
         "distinct": "Y",
-        "fromDateName": "facilityGroupFromDate",
-        "thruDateName": "facilityGroupThruDate",
-        "filterByDate": "Y",
-        "fieldList": ["facilityId", "facilityName", "fromDate"],
+        "fieldList": ["facilityId", "facilityName"],
         // By default we show only 20 facilities, others get rendered on search query.
         "viewSize": 20
       }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #220

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed all facilities not showing in the select facilities modal in the facility group card.
- Earlier we were fetching the facilities with "FacilityView" entity which don't fetch facilities which have thruDate of group association in it.
- Instead now we are using "Facility" entity to fetch all the facility regardless of their linking with group.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)