### PR TITLE
Fixed: Able to redirect to the find facilities page(#222)

### DIFF
--- a/src/components/GroupActionsPopover.vue
+++ b/src/components/GroupActionsPopover.vue
@@ -50,7 +50,7 @@ export default defineComponent({
   methods: {
     async viewFacilities(facilityGroupId: string) {
       await this.store.dispatch('facility/updateFacilityQuery', { ...this.facilityQuery, facilityGroupId })
-      this.$router.push({ path: `/find-facilities` })
+      this.$router.push({ path: `/tabs/find-facilities` })
       popoverController.dismiss()
     },
     async openAddFacilityToGroupsModal(facilityGroupId: any) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -111,7 +111,7 @@ router.beforeEach((to, from) => {
   if (to.meta.permissionId && !hasPermission(to.meta.permissionId)) {
     let redirectToPath = from.path;
     // If the user has navigated from Login page or if it is page load, redirect user to settings page without showing any toast
-    if (redirectToPath == "/login" || redirectToPath == "/") redirectToPath = "/settings";
+    if (redirectToPath == "/login" || redirectToPath == "/") redirectToPath = "/tabs/settings";
     else showToast(translate('You do not have permission to access this page'));
     return {
       path: redirectToPath,

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
-        <ion-back-button default-href="/find-facilities" slot="start" />
+        <ion-back-button default-href="/tabs/find-facilities" slot="start" />
         <ion-title>{{ translate("Add Store Address") }}</ion-title>
       </ion-toolbar>
     </ion-header>

--- a/src/views/AddFacilityConfig.vue
+++ b/src/views/AddFacilityConfig.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
-        <ion-back-button default-href="/find-facilities" slot="start" />
+        <ion-back-button default-href="/tabs/find-facilities" slot="start" />
         <ion-title>{{ translate("Add Store Configuration") }}</ion-title>
       </ion-toolbar>
     </ion-header>

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
-        <ion-back-button default-href="/find-facilities" slot="start" />
+        <ion-back-button default-href="/tabs/find-facilities" slot="start" />
         <ion-title>{{ translate("Add Store") }}</ion-title>
       </ion-toolbar>
     </ion-header>

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header>
       <ion-toolbar>
-        <ion-back-button slot="start" default-href="/find-facilities"/>
+        <ion-back-button slot="start" default-href="/tabs/find-facilities"/>
         <ion-title>{{ translate("Facility details") }}</ion-title>
       </ion-toolbar>
     </ion-header>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#222 

### Short Description and Why It's Useful
After navigating to the facility details page, when the user clicks on the back button, the find-facilities page should open. Also, fix this issue in other components where navigating back to the find-facilities page is not working.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)