### PR TITLE
Improved: added validation on fav icon in modal to associate facilites, groupType and product to a facility group (#223)

### DIFF
--- a/src/components/AddFacilityToGroupModal.vue
+++ b/src/components/AddFacilityToGroupModal.vue
@@ -31,7 +31,7 @@
       </div>
     </ion-list>
     <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-      <ion-fab-button @click="confirmSave()">
+      <ion-fab-button :disabled="!areFacilitiesUpdated()" @click="confirmSave()">
         <ion-icon :icon="saveOutline" />
       </ion-fab-button>
     </ion-fab>
@@ -216,6 +216,11 @@ export default defineComponent({
       };
       await this.store.dispatch('facility/fetchFacilityGroups', payload)
     },
+    areFacilitiesUpdated() {
+      if(this.selectedFacilities.length !== this.selectedFacilityValues.length) return true;
+
+      return this.selectedFacilityValues.some((selectedFacility: any) => !this.selectedFacilities.find((facility: any) => facility.facilityId === selectedFacility.facilityId))
+    }
   },
   setup() {
     const store = useStore();

--- a/src/components/AddProductStoreToGroupModal.vue
+++ b/src/components/AddProductStoreToGroupModal.vue
@@ -164,7 +164,9 @@ export default defineComponent({
       await this.store.dispatch('facility/updateFacilityGroups', this.groups)
     },
     areProductStoresUpdated() {
-      return JSON.stringify(this.selectedProductStoreValues) !== JSON.stringify(this.selectedProductStores)
+      if(this.selectedProductStores.length !== this.selectedProductStoreValues.length) return true;
+
+      return this.selectedProductStoreValues.some((selectedProductStore: any) => !this.selectedProductStores.find((productStore: any) => productStore.productStoreId === selectedProductStore.productStoreId))
     }
   },
   setup() {

--- a/src/components/GroupTypeModal.vue
+++ b/src/components/GroupTypeModal.vue
@@ -31,7 +31,7 @@
     </form>
 
     <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-      <ion-fab-button @click="saveGroupType()">
+      <ion-fab-button :disabled="!areGroupTypesUpdated()" @click="saveGroupType()">
         <ion-icon :icon="saveOutline" />
       </ion-fab-button>
     </ion-fab>
@@ -118,6 +118,9 @@ export default defineComponent({
         showToast(translate("Failed to update facility group type."))
         logger.error(err)
       }
+    },
+    areGroupTypesUpdated() {
+      return this.facilityGroup.facilityGroupTypeId !== this.facilityGroupValue.facilityGroupTypeId
     }
   },
   setup() {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #223

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added check on fav button in below modals to disabled when nothing changes.
- Add facility to group modal.
- Add product stores to group modal.
- Select grouptypes for a group modal.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)