### PR TITLE
Fixed: zipcode label not showing in facility address modal (#162)

### DIFF
--- a/src/components/FacilityAddressModal.vue
+++ b/src/components/FacilityAddressModal.vue
@@ -45,7 +45,7 @@
       </ion-item>
       <ion-item>
         <ion-input label-placement="floating" v-model="address.postalCode">
-          <div position="floating">{{ translate("Zipcode") }} <ion-text color="danger">*</ion-text></div>
+          <div slot="label">{{ translate("Zipcode") }} <ion-text color="danger">*</ion-text></div>
         </ion-input>
       </ion-item>
       <ion-item-divider color="light">

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -31,7 +31,7 @@
             </ion-item>
             <ion-item>
               <ion-input label-placement="floating" v-model="formData.postalCode">
-                <div>{{ translate('Zipcode') }} <ion-text color="danger">*</ion-text></div>
+                <div slot="label">{{ translate('Zipcode') }} <ion-text color="danger">*</ion-text></div>
               </ion-input>
             </ion-item>
             <ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #162

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed the position of the zipcode label to be shown in the facility address creation and updation.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before 
![Screenshot from 2024-04-10 14-25-24](https://github.com/hotwax/facilities/assets/69574321/550f06f4-3181-4595-97b9-f169ae0b1546)


After
![Screenshot from 2024-04-10 14-24-48](https://github.com/hotwax/facilities/assets/69574321/dbaf898e-9957-4b7b-a8da-8801fca8c95c)



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)