### PR TITLE
Fixed: infinite scroll issue when used with searchbar(dxp-289)

### DIFF
--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -105,7 +105,13 @@
           </ion-fab-button>
         </ion-fab-list>
       </ion-fab>
-
+        <!--
+        When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+        In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
+        The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
+        To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
+        whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+      -->
       <ion-infinite-scroll
         @ionInfinite="loadMoreFacilities($event)"
         threshold="100px"

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -110,6 +110,7 @@
         @ionInfinite="loadMoreFacilities($event)"
         threshold="100px"
         :disabled="!isScrollable"
+        :key="query.queryString"
       >
         <ion-infinite-scroll-content
           loading-spinner="crescent"

--- a/src/views/FindGroups.vue
+++ b/src/views/FindGroups.vue
@@ -65,6 +65,7 @@
         @ionInfinite="loadMoreGroups($event)"
         threshold="100px"
         :disabled="!isScrollable"
+        :key="query.queryString"
       >
         <ion-infinite-scroll-content
           loading-spinner="crescent"


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
https://github.com/hotwax/dxp-components/issues/289

### Short Description and Why It's Useful
In Ionic 7.6.0, an issue was fixed that caused infinite scroll to trigger when quickly scrolling or when items had not filled the entire page. This issue resulted in infinite scroll problems when used with search functionality. A key was added to the infinite scroll to trigger a re-render when the keyword is changed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)