### PR TITLE
Fixed: Infinite scroll with searchbar and loading bug(#289)

### DIFF
--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -117,7 +117,7 @@
       <ion-infinite-scroll
         @ionInfinite="loadMoreFacilities($event)"
         threshold="100px"
-        v-show="isScrollingEnabled && isScrollable"
+        v-show="isScrollable"
         ref="infiniteScrollRef"
       >
         <ion-infinite-scroll-content
@@ -259,6 +259,10 @@ export default defineComponent({
       }
     },
     async loadMoreFacilities(event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if(!(this.isScrollingEnabled && this.isScrollable)) {
+        await event.target.complete();
+      }
       this.fetchFacilities(
         undefined,
         Math.ceil(

--- a/src/views/FindGroups.vue
+++ b/src/views/FindGroups.vue
@@ -64,7 +64,7 @@
       <ion-infinite-scroll
         @ionInfinite="loadMoreGroups($event)"
         threshold="100px"
-        v-show="isScrollingEnabled && isScrollable"
+        v-show="isScrollable"
         ref="infiniteScrollRef"
       >
         <ion-infinite-scroll-content
@@ -193,6 +193,10 @@ export default defineComponent({
       }
     },
     async loadMoreGroups(event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if(!(this.isScrollingEnabled && this.isScrollable)) {
+        await event.target.complete();
+      }
       this.fetchGroups(
         undefined,
         Math.ceil(


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/289
### Short Description and Why It's Useful
Removed the logic to re-render the infinite-scroll on queryString check that has been added in the previous PR.

Added a variable to check whether the scrolling can be enabled or not whenever users lands on the list page. For this, we have determined the height of the content part scroll and infiniteScroll component and if the height is less than 0 then only enabling the infinite-scroll component

Removed disabled as once the infiniteScroll is disabled it does not gets enabled again, hence removed the disabled property and instead used v-show to enable/disable infinite scroll.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)