### PR TITLE
Fixed: Interaction Issues in Product Stores Modal(#253)

### DIFF
--- a/src/components/AddProductStoreToGroupModal.vue
+++ b/src/components/AddProductStoreToGroupModal.vue
@@ -109,7 +109,6 @@ export default defineComponent({
           "noConditionFind": "Y",
           "filterByDate": 'Y'
         })
-        emitter.emit('dismissLoader');
 
         if(!hasError(resp)) {
           this.selectedProductStores = resp.data.docs
@@ -120,6 +119,7 @@ export default defineComponent({
       } catch(err) {
         logger.error(err)
       }
+      emitter.emit('dismissLoader');
     },
     isSelected(productStoreId: any) {
       return this.selectedProductStoreValues.some((productStore: any) => productStore.productStoreId === productStoreId);

--- a/src/components/AddProductStoreToGroupModal.vue
+++ b/src/components/AddProductStoreToGroupModal.vue
@@ -55,6 +55,8 @@ import logger from "@/logger";
 import { hasError } from "@/adapter";
 import { showToast } from "@/utils";
 import { DateTime } from "luxon";
+import emitter from "@/event-bus";
+
 
 export default defineComponent({
   name: "AddProductStoreToGroupModal",
@@ -96,6 +98,7 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true});
     },
     async fetchGroupProductStores() {
+      emitter.emit('presentLoader')
        try {
         const resp = await FacilityService.fetchAssociatedProductStoresToGroup({
           "inputFields": {
@@ -106,6 +109,7 @@ export default defineComponent({
           "noConditionFind": "Y",
           "filterByDate": 'Y'
         })
+        emitter.emit('dismissLoader');
 
         if(!hasError(resp)) {
           this.selectedProductStores = resp.data.docs
@@ -182,4 +186,9 @@ export default defineComponent({
   },
 });
 </script>
+<style scoped>
+ion-content {
+  --padding-bottom: 80px;
+}
+</style>
     

--- a/src/views/FindGroups.vue
+++ b/src/views/FindGroups.vue
@@ -41,7 +41,7 @@
               <ion-icon :icon="bagHandleOutline" slot="start"/>
               <ion-label>{{ translate('Product stores') }}</ion-label>
               <ion-chip outline slot="end" @click="openAddProductStoreToGroupModal(group)">
-                {{ group.productStoreCount }}
+                {{ group.productStoreCount || 0 }}
               </ion-chip>
             </ion-item>
             <ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#253 
### Short Description and Why It's Useful
-  When no product stores are selected, the chip within a faciliy group should display "0".
- Added `bottom-padding` in the `ion-content` for preventing the overlapping of `ion-fab-button`.
- Added loader while opening the modal to prevent the delay tick marks on the Product stores.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)