### PR TITLE
Improved: aligned items to start in the find groups page (#165)

### DIFF
--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -293,6 +293,7 @@ body {
   display: grid;
   grid-template-areas: "search"
                        "main";
+  align-items: start;
 }
 
 .find > .filters{


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#165

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added align items start css to the find class.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-07-15 15-52-24](https://github.com/user-attachments/assets/312a5294-ce89-4ddd-b9cb-5e151160838c)

After
![Screenshot from 2024-07-15 15-52-51](https://github.com/user-attachments/assets/c788baf1-13d8-43bf-841d-63b40a68e65c)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)