### PR TITLE
Improved: error handling while parking creation to show error message from server (#185)

### DIFF
--- a/src/components/CreateVirtualFacilityModal.vue
+++ b/src/components/CreateVirtualFacilityModal.vue
@@ -137,9 +137,13 @@ export default defineComponent({
         } else {
           throw resp.data;
         }
-      } catch (error) {
+      } catch (error: any) {
         logger.error(error)
-        showToast(translate('Failed to create parking.'))
+        if(error?.response?.data?.error?.message) {
+          showToast(error.response.data.error.message)
+        } else {
+          showToast(translate('Failed to create parking.'))
+        }
       }
       modalController.dismiss()
     },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#185

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Displaying error message from server dynamically in case of parking creation api fails due to duplicate facilityId.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)