### PR TITLE
Improved: pre-filling the custom order limit alert input with the current maxorder limit

### DIFF
--- a/src/components/OrderLimitPopover.vue
+++ b/src/components/OrderLimitPopover.vue
@@ -77,6 +77,7 @@ export default defineComponent({
           name: "setLimit",
           placeholder: translate("Order fulfillment capacity"),
           type: "number",
+          value: this.fulfillmentOrderLimit?.toString(),
           min: 0
         }] : [],
         buttons: [{


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/available-to-promise/pull/362

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Prefilling the alert input in the custom maxOrder limit popover with the existing fulfillment order limit.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)