### PR TITLE
Improved: restricted the card height to the content in parkings page (#291)

### DIFF
--- a/src/views/Parking.vue
+++ b/src/views/Parking.vue
@@ -235,6 +235,7 @@ main {
   grid-template-columns: repeat(auto-fill, minmax(300px, 343px));
   max-width: 1000px;
   margin: auto;
+  align-items: start;
 }
 
 @media screen and (min-width: 991px) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#291

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Restricted the parking card height to the card content.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-09-03 18-47-57](https://github.com/user-attachments/assets/8b7bd164-87d4-4f75-8893-dcdc9dfdc0d5)

After
![Screenshot from 2024-09-03 18-39-00](https://github.com/user-attachments/assets/8ddcd3e7-6af5-44da-b8cf-e504c4f0a752)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)