### PR TITLE
Fixed: miscellaneous fixes related to new facility group UI. 

### DIFF
--- a/src/views/CreateFacilityGroup.vue
+++ b/src/views/CreateFacilityGroup.vue
@@ -13,45 +13,43 @@
           <ion-card-header>
             <ion-card-title>{{ translate('Create a new group') }}</ion-card-title>
           </ion-card-header>
-          <form @keyup.enter="createFacilityGroup">
-            <ion-list>
-              <ion-item>
-                <ion-input label-placement="floating" @ionBlur="setFacilityGroupId($event)" v-model="formData.facilityGroupName">
-                  <div slot="label">{{ translate("Name") }} <ion-text color="danger">*</ion-text></div>
-                </ion-input>
-              </ion-item>
-              <ion-item lines="none">
-                <ion-input label-placement="floating" :label="translate('Internal ID')" ref="facilityGroupId" v-model="formData.facilityGroupId" @ionInput="validateFacilityGroupId" @ionBlur="markFacilityGroupIdTouched" :error-text="translate('Internal ID cannot be more than 20 characters.')" />
-              </ion-item>
-              <ion-item>
-                <ion-select :label="translate('Group type')" :disabled="isFacilityGroupTypeDisabled" :placeholder="translate('Select')" interface="popover" v-model="formData.facilityGroupTypeId">
-                  <ion-select-option :value="facilityGroupType.facilityGroupTypeId" :key="facilityGroupType.facilityGroupTypeId" v-for="facilityGroupType in facilityGroupTypes">
-                    {{  facilityGroupType.description ?  facilityGroupType.description : facilityGroupType.facilityGroupTypeId }}
-                  </ion-select-option>
-                </ion-select>
-              </ion-item>
-              <ion-item>
-                <ion-select v-if="productStores.length" :label="translate('Product store')" :placeholder="translate('Select')" :selectedText="selectedProductStoreIds.length > 1 ? translate('product stores', { count: selectedProductStoreIds.length }) : selectedProductStoreIds.map[0]" :value="selectedProductStoreIds" @ionChange="updateFacilityGroupProductStores($event)" :multiple="true">
-                  <ion-select-option :value="productStore.productStoreId" :key="productStore.productStoreId" v-for="productStore in productStores">
-                    {{ productStore.storeName ? productStore.storeName : productStore.productStoreId }}
-                  </ion-select-option>
-                </ion-select>
-              </ion-item>
-              <ion-item lines="none">
-                <ion-textarea :label="translate('Description')" label-placement="floating"
-                  :placeholder="translate('group description')"
-                  :auto-grow="true"
-                  :counter="true" 
-                  :maxlength="255"
-                  v-model="formData.description"
-                >
-                </ion-textarea>
-              </ion-item>
-            </ion-list>
-          </form>
+          <ion-list>
+            <ion-item>
+              <ion-input label-placement="floating" @ionBlur="setFacilityGroupId($event)" v-model="formData.facilityGroupName">
+                <div slot="label">{{ translate("Name") }} <ion-text color="danger">*</ion-text></div>
+              </ion-input>
+            </ion-item>
+            <ion-item lines="none">
+              <ion-input label-placement="floating" :label="translate('Internal ID')" ref="facilityGroupId" v-model="formData.facilityGroupId" @ionInput="validateFacilityGroupId" @ionBlur="markFacilityGroupIdTouched" :error-text="translate('Internal ID cannot be more than 20 characters.')" />
+            </ion-item>
+            <ion-item>
+              <ion-select :label="translate('Group type')" :disabled="isFacilityGroupTypeDisabled" :placeholder="translate('Select')" interface="popover" v-model="formData.facilityGroupTypeId">
+                <ion-select-option :value="facilityGroupType.facilityGroupTypeId" :key="facilityGroupType.facilityGroupTypeId" v-for="facilityGroupType in facilityGroupTypes">
+                  {{  facilityGroupType.description ?  facilityGroupType.description : facilityGroupType.facilityGroupTypeId }}
+                </ion-select-option>
+              </ion-select>
+            </ion-item>
+            <ion-item>
+              <ion-select v-if="productStores.length" :label="translate('Product store')" :placeholder="translate('Select')" :selectedText="selectedProductStoreIds.length > 1 ? translate('product stores', { count: selectedProductStoreIds.length }) : selectedProductStoreIds.map[0]" :value="selectedProductStoreIds" @ionChange="updateFacilityGroupProductStores($event)" :multiple="true">
+                <ion-select-option :value="productStore.productStoreId" :key="productStore.productStoreId" v-for="productStore in productStores">
+                  {{ productStore.storeName ? productStore.storeName : productStore.productStoreId }}
+                </ion-select-option>
+              </ion-select>
+            </ion-item>
+            <ion-item lines="none">
+              <ion-textarea :label="translate('Description')" label-placement="floating"
+                :placeholder="translate('group description')"
+                :auto-grow="true"
+                :counter="true" 
+                :maxlength="255"
+                v-model="formData.description"
+              >
+              </ion-textarea>
+            </ion-item>
+          </ion-list>
         </ion-card>
         <div class="ion-text-center ion-margin">
-          <ion-button @click="createFacilityGroup()" @keyup.enter.stop>
+          <ion-button @click="createFacilityGroup()">
             {{ translate("Create group") }}
             <ion-icon slot="end" :icon="arrowForwardOutline"/>
           </ion-button>

--- a/src/views/FindGroups.vue
+++ b/src/views/FindGroups.vue
@@ -193,6 +193,7 @@ export default defineComponent({
   async ionViewWillEnter() {
     this.segment = "facility-groups"
     await this.fetchGroups();
+    await this.resetParentGroupPage()
   },
   methods: {
     async resetParentGroupPage() {

--- a/src/views/ManageFacilities.vue
+++ b/src/views/ManageFacilities.vue
@@ -139,6 +139,7 @@
     async ionViewWillEnter() {
       emitter.emit('presentLoader')
       this.isSavingDetail = false
+      this.queryString = ''
       await Promise.all([this.fetchFacilities(), this.fetchFacilityGroup()])
       await this.fetchMemberFacilities();
       await this.getFilteredFacilities();

--- a/src/views/ManageFacilities.vue
+++ b/src/views/ManageFacilities.vue
@@ -310,12 +310,13 @@
       },
       async save () {
         this.isSavingDetail = true
-        const facilitiesToAdd = this.selectedFacilities.filter((facility: any) => !facility.fromDate)
+        const memberFacilityIds = this.memberFacilities?.map((facility: any) => facility.facilityId)
+        const facilitiesToAdd = this.selectedFacilities.filter((facility: any) => !memberFacilityIds.includes(facility.facilityId))
         const selectedFacilityIds = this.selectedFacilities ? new Set(this.selectedFacilities.map((facility:any) => facility.facilityId)) as any : [];
         const facilitiesToRemove = this.memberFacilities.filter((facility: any) => !selectedFacilityIds.has(facility.facilityId))
         
         const removeResponses = await Promise.allSettled(facilitiesToRemove
-          .map(async (facility: any) => await FacilityService.updateFacilityToGroup({
+          .map((facility: any) => FacilityService.updateFacilityToGroup({
             "facilityId": facility.facilityId,
             "facilityGroupId": facility.facilityGroupId,
             "fromDate": facility.fromDate,
@@ -324,7 +325,7 @@
         )
 
         const addResponses = await Promise.allSettled(facilitiesToAdd
-          .map(async (facility: any) => await FacilityService.addFacilityToGroup({
+          .map((facility: any) => FacilityService.addFacilityToGroup({
             "facilityId": facility.facilityId,
             "facilityGroupId": this.facilityGroupId,
             "sequenceNum": facility.sequenceNum
@@ -334,11 +335,17 @@
         const facilityIdsToAdd = facilitiesToAdd ? new Set(facilitiesToAdd.map((facility:any) => facility.facilityId)) as any : [];
         const existingFacilityMembers = this.selectedFacilities.filter((facility:any) => !facilityIdsToAdd.has(facility.facilityId))
         const diffMemberFacilitySequencing = existingFacilityMembers.filter((facility: any) => this.memberFacilities.some((memberFacility: any) => memberFacility.facilityId === facility.facilityId && memberFacility.sequenceNum !== facility.sequenceNum))
-        const sequenceUpdateResponses = await Promise.allSettled(diffMemberFacilitySequencing.map(async (memberFacility: any) => {
-          await FacilityService.updateFacilityToGroup({
+        
+        const memberFacilityDetail = this.memberFacilities.reduce((memberInfo:any, facility:any) => {
+          memberInfo[facility.facilityId] = facility;
+          return memberInfo;
+        }, {});
+
+        const sequenceUpdateResponses = await Promise.allSettled(diffMemberFacilitySequencing.map((memberFacility: any) => {
+          FacilityService.updateFacilityToGroup({
             "facilityId": memberFacility.facilityId,
-            "facilityGroupId": memberFacility.facilityGroupId,
-            "fromDate": memberFacility.fromDate,
+            "facilityGroupId": this.facilityGroupId,
+            "fromDate": memberFacilityDetail[memberFacility.facilityId].fromDate,
             "sequenceNum": memberFacility.sequenceNum
           });
         }))


### PR DESCRIPTION
### Related Issues
#305 #306 #307 #308
#

### Short Description and Why It's Useful
1) Fixed: Corrected logic to avoid saving duplicate members when adding/removing multiple times from the manage facilities page.
2) Fixed: Reset query string on reopening the manage facilities page after saving.
3) Fixed: Parent Group Association Not Opening After Tab Switching·
4) Fixed: Pressing Enter or Shift+Enter in any input field during facility group creation leads to the next step for creating a facility group.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)