### PR TITLE
Improved: changed logic of api call for adding mutilple productStores to a facility(#309)

### DIFF
--- a/src/views/AddFacilityConfig.vue
+++ b/src/views/AddFacilityConfig.vue
@@ -298,13 +298,14 @@ export default defineComponent({
       }
     },
     async addProductStoresToFacility() {
-      const responses = await Promise.allSettled(this.selectedProductStores
-        .map(async (payload: any) => await FacilityService.createProductStoreFacility({
+      let responses = []
+      for (const payload of this.selectedProductStores) {
+        responses.push(await FacilityService.createProductStoreFacility({
           productStoreId: payload.productStoreId,
           facilityId: this.facilityId,
           fromDate: DateTime.now().toMillis(),
         }))
-      )
+      }
 
       const hasFailedResponse = responses.some((response: any) => response.status === 'rejected')
       if (hasFailedResponse) {

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -791,13 +791,14 @@ export default defineComponent({
             }))
           )
 
-          const createResponses = await Promise.allSettled(productStoresToCreate
-            .map(async (payload: any) => await FacilityService.createProductStoreFacility({
+          let createResponses = []
+          for (const payload of productStoresToCreate) {
+            createResponses.push(await FacilityService.createProductStoreFacility({
               productStoreId: payload.productStoreId,
               facilityId: this.facilityId,
               fromDate: DateTime.now().toMillis(),
             }))
-          )
+          }
 
           const hasFailedResponse = [...updateResponses, ...createResponses].some((response: any) => response.status === 'rejected')
           if(hasFailedResponse) {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#309 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Earlier, all calls were made at the same time (in parallel), which could have caused concurrency issues and the error `Transaction is marked for rollback.`
- Now, the calls are made one after another (sequentially), which helps avoid these concurrency problems.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)