### PR TITLE
Improved: Added a toast when we cannot set the product store as primary due to a missing Shopify shop(#304)

### DIFF
--- a/src/components/ProductStorePopover.vue
+++ b/src/components/ProductStorePopover.vue
@@ -118,6 +118,8 @@ export default defineComponent({
 
       // if we does not get shopify shop id for the store then not making product store as primary
       if(!shopifyShopId) {
+        showToast(translate('Failed to make product store primary due to missing Shopify shop'))
+        emitter.emit('dismissLoader')
         return;
       }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -144,6 +144,7 @@
   "Failed to find the facility locations": "Failed to find the facility locations",
   "Failed to make product store as primary.": "Failed to make product store as primary.",
   "Failed to make product store primary.": "Failed to make product store primary.",
+  "Failed to make product store primary due to missing Shopify shop": "Failed to make product store primary due to missing Shopify shop",
   "Failed to regenerate latitude and longitude for the facility.": "Failed to regenerate latitude and longitude for the facility.",
   "Failed to rename facility.": "Failed to rename facility.",
   "Failed to remove facility latitude and longitude.": "Failed to remove facility latitude and longitude.",

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -172,7 +172,7 @@
             </ion-card-header>
             <ion-item v-for="store in facilityProductStores" :key="store.productStoreId">
               <ion-label>{{ getProductStore(store.productStoreId)?.storeName }}</ion-label>
-              <ion-badge slot="end" v-if="shopifyShopIdForProductStore(store.productStoreId) === current.primaryFacilityGroupId">{{ translate("primary store") }}</ion-badge>
+              <ion-badge slot="end" v-if="shopifyShopIdForProductStore(store.productStoreId) !== '' && shopifyShopIdForProductStore(store.productStoreId) === current.primaryFacilityGroupId">{{ translate("primary store") }}</ion-badge>
               <ion-button slot="end" fill="clear" color="medium" @click="productStorePopover($event, store)">
                 <ion-icon slot="icon-only" :icon="ellipsisVerticalOutline" />
               </ion-button>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#304 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a toast when we cannot set the product store as primary due to a missing Shopify shop.
- Also update the locale file with the toast text message.
- Also added a check to avoid adding the ion-badge to product stores without a Shopify shop ID.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)