### PR TITLE
Improved: Fixed popover not closing and corrected the primary store tag display issue(#304)

### DIFF
--- a/src/components/ProductStorePopover.vue
+++ b/src/components/ProductStorePopover.vue
@@ -71,11 +71,15 @@ export default defineComponent({
           // TODO: need to check if we need to remove primary value from the facility if product store is removed.
           // Removing primaryFacilityGroupId from the facility, if present
           if(this.shopifyShopIdForProductStore(this.currentProductStore.productStoreId) === this.current.primaryFacilityGroupId) {
-            await FacilityService.updateFacility({
+            const updateResp = await FacilityService.updateFacility({
               facilityId: this.facilityId,
               primaryFacilityGroupId: ''
-            })
-            await this.store.dispatch('facility/updateCurrentFacility', { ...this.current, primaryFacilityGroupId: '' })
+            });
+            if (!hasError(updateResp)) {
+              await this.store.dispatch('facility/updateCurrentFacility', { ...this.current, primaryFacilityGroupId: '' });
+            } else {
+              throw updateResp.data;
+            }
           }
           // refetching product stores with updated roles
           await this.store.dispatch('facility/getFacilityProductStores', { facilityId: this.facilityId })

--- a/src/components/ProductStorePopover.vue
+++ b/src/components/ProductStorePopover.vue
@@ -75,8 +75,8 @@ export default defineComponent({
               facilityId: this.facilityId,
               primaryFacilityGroupId: ''
             })
+            await this.store.dispatch('facility/updateCurrentFacility', { ...this.current, primaryFacilityGroupId: '' })
           }
-          await this.store.dispatch('facility/updateCurrentFacility', { ...this.current, primaryFacilityGroupId: '' })
           // refetching product stores with updated roles
           await this.store.dispatch('facility/getFacilityProductStores', { facilityId: this.facilityId })
         } else {

--- a/src/components/ProductStorePopover.vue
+++ b/src/components/ProductStorePopover.vue
@@ -76,7 +76,7 @@ export default defineComponent({
               primaryFacilityGroupId: ''
             })
           }
-
+          await this.store.dispatch('facility/updateCurrentFacility', { ...this.current, primaryFacilityGroupId: '' })
           // refetching product stores with updated roles
           await this.store.dispatch('facility/getFacilityProductStores', { facilityId: this.facilityId })
         } else {
@@ -119,6 +119,7 @@ export default defineComponent({
       // if we does not get shopify shop id for the store then not making product store as primary
       if(!shopifyShopId) {
         showToast(translate('Failed to make product store primary due to missing Shopify shop'))
+        popoverController.dismiss()
         emitter.emit('dismissLoader')
         return;
       }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#304 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Fixed the issue where the product store option popover was not closing when setting the store as primary.
- Corrected the primary store tag display to appear as expected when relinking a store that was previously set as the primary before being unlinked.


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)