### PR TITLE
Improved: Added a flag to prevent auto-population of the facility ID after it has been manually edited(#265)

### DIFF
--- a/src/components/CreateVirtualFacilityModal.vue
+++ b/src/components/CreateVirtualFacilityModal.vue
@@ -91,11 +91,14 @@ export default defineComponent({
         facilityId: '',
         description: '',
       },
+      isVirtualFacIdManuallySet: false
     }
   },
   methods: {
     setFacilityId(event: any) {
-      this.formData.facilityId = generateInternalId(event.target.value)
+      if(!this.isVirtualFacIdManuallySet) {
+        this.formData.facilityId = generateInternalId(event.target.value)
+      }
     },
     closeModal() {
       modalController.dismiss();
@@ -157,6 +160,7 @@ export default defineComponent({
       this.formData.facilityId.length <= 20
         ? (this as any).$refs.facilityId.$el.classList.add('ion-valid')
         : (this as any).$refs.facilityId.$el.classList.add('ion-invalid');
+      this.isVirtualFacIdManuallySet = true;
     },
     markFacilityIdTouched() {
       (this as any).$refs.facilityId.$el.classList.add('ion-touched');

--- a/src/components/CreateVirtualFacilityModal.vue
+++ b/src/components/CreateVirtualFacilityModal.vue
@@ -91,12 +91,12 @@ export default defineComponent({
         facilityId: '',
         description: '',
       },
-      isVirtualFacIdManuallySet: false
+      isAutoGenerateId: true
     }
   },
   methods: {
     setFacilityId(event: any) {
-      if(!this.isVirtualFacIdManuallySet) {
+      if(this.isAutoGenerateId) {
         this.formData.facilityId = generateInternalId(event.target.value)
       }
     },
@@ -160,7 +160,7 @@ export default defineComponent({
       this.formData.facilityId.length <= 20
         ? (this as any).$refs.facilityId.$el.classList.add('ion-valid')
         : (this as any).$refs.facilityId.$el.classList.add('ion-invalid');
-      this.isVirtualFacIdManuallySet = true;
+      this.isAutoGenerateId = false;
     },
     markFacilityIdTouched() {
       (this as any).$refs.facilityId.$el.classList.add('ion-touched');

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -111,7 +111,7 @@ export default defineComponent({
       },
       selectedFacilityTypeId: '' as any,
       facilityTypesByParentTypeId: {} as any,
-      isFacilityIdManuallySet: false,
+      isAutoGenerateId: true,
     }
   },
   async ionViewWillEnter() {
@@ -139,10 +139,10 @@ export default defineComponent({
         facilityId: '',
         externalId: '',
       }
-      this.isFacilityIdManuallySet = false;
+      this.isAutoGenerateId = true;
     },
     setFacilityId(event: any) {
-      if(!this.isFacilityIdManuallySet) {
+      if(this.isAutoGenerateId) {
         this.formData.facilityId = generateInternalId(event.target.value)
       }
     },
@@ -218,7 +218,7 @@ export default defineComponent({
       this.formData.facilityId.length <= 20
         ? (this as any).$refs.facilityId.$el.classList.add('ion-valid')
         : (this as any).$refs.facilityId.$el.classList.add('ion-invalid');
-      this.isFacilityIdManuallySet = true;
+      this.isAutoGenerateId = false;
     },
     markFacilityIdTouched() {
       (this as any).$refs.facilityId.$el.classList.add('ion-touched');

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -110,7 +110,8 @@ export default defineComponent({
         externalId: '',
       },
       selectedFacilityTypeId: '' as any,
-      facilityTypesByParentTypeId: {} as any
+      facilityTypesByParentTypeId: {} as any,
+      isFacilityIdManuallySet: false,
     }
   },
   async ionViewWillEnter() {
@@ -138,9 +139,12 @@ export default defineComponent({
         facilityId: '',
         externalId: '',
       }
+      this.isFacilityIdManuallySet = false;
     },
     setFacilityId(event: any) {
-      this.formData.facilityId = generateInternalId(event.target.value)
+      if(!this.isFacilityIdManuallySet) {
+        this.formData.facilityId = generateInternalId(event.target.value)
+      }
     },
     async createFacility() {
       if (!this.formData.facilityName?.trim()) {
@@ -214,6 +218,7 @@ export default defineComponent({
       this.formData.facilityId.length <= 20
         ? (this as any).$refs.facilityId.$el.classList.add('ion-valid')
         : (this as any).$refs.facilityId.$el.classList.add('ion-invalid');
+      this.isFacilityIdManuallySet = true;
     },
     markFacilityIdTouched() {
       (this as any).$refs.facilityId.$el.classList.add('ion-touched');

--- a/src/views/CreateFacilityGroup.vue
+++ b/src/views/CreateFacilityGroup.vue
@@ -130,7 +130,8 @@ export default defineComponent({
         description: '',
       },
       isFacilityGroupTypeDisabled: false,
-      selectedProductStoreIds: []
+      selectedProductStoreIds: [],
+      isFacilityGroupIdManuallySet: false
     }
   },
   props: ['selectedFacilityGroupTypeId'],
@@ -147,7 +148,9 @@ export default defineComponent({
       this.selectedProductStoreIds = selectedProductStoreIds
     },
     setFacilityGroupId(event: any) {
-      this.formData.facilityGroupId = generateInternalId(event.target.value)
+      if(!this.isFacilityGroupIdManuallySet) {
+        this.formData.facilityGroupId = generateInternalId(event.target.value)
+      }
     },
     async createFacilityGroup() {
       if (!this.formData.facilityGroupName?.trim()) {
@@ -236,6 +239,7 @@ export default defineComponent({
       this.formData.facilityGroupId.length <= 20
         ? (this as any).$refs.facilityGroupId.$el.classList.add('ion-valid')
         : (this as any).$refs.facilityGroupId.$el.classList.add('ion-invalid');
+      this.isFacilityGroupIdManuallySet = true
     },
     markFacilityGroupIdTouched() {
       (this as any).$refs.facilityGroupId.$el.classList.add('ion-touched');

--- a/src/views/CreateFacilityGroup.vue
+++ b/src/views/CreateFacilityGroup.vue
@@ -131,7 +131,7 @@ export default defineComponent({
       },
       isFacilityGroupTypeDisabled: false,
       selectedProductStoreIds: [],
-      isFacilityGroupIdManuallySet: false
+      isAutoGenerateId: true
     }
   },
   props: ['selectedFacilityGroupTypeId'],
@@ -148,7 +148,7 @@ export default defineComponent({
       this.selectedProductStoreIds = selectedProductStoreIds
     },
     setFacilityGroupId(event: any) {
-      if(!this.isFacilityGroupIdManuallySet) {
+      if(this.isAutoGenerateId) {
         this.formData.facilityGroupId = generateInternalId(event.target.value)
       }
     },
@@ -239,7 +239,7 @@ export default defineComponent({
       this.formData.facilityGroupId.length <= 20
         ? (this as any).$refs.facilityGroupId.$el.classList.add('ion-valid')
         : (this as any).$refs.facilityGroupId.$el.classList.add('ion-invalid');
-      this.isFacilityGroupIdManuallySet = true
+      this.isAutoGenerateId = false
     },
     markFacilityGroupIdTouched() {
       (this as any).$refs.facilityGroupId.$el.classList.add('ion-touched');


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#265 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added a check to prevent auto-population of the facilityId and facilityGroupId after manual edits, as they were previously auto-populated after every facilityName update.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)