### PR TITLE
Fixed: Modal will display `Other` as group type for unlinked facility groups(#258)

### DIFF
--- a/src/components/AddFacilityGroupModal.vue
+++ b/src/components/AddFacilityGroupModal.vue
@@ -16,7 +16,7 @@
     <form @keyup.enter="updateGroups">
       <ion-list>
         <ion-item-group v-for="(groups, typeId) in filteredFacilityGroupsByType" :key="typeId">
-          <ion-item-divider color="medium">{{ getFacilityGroupTypeDesc(typeId) }}</ion-item-divider>
+          <ion-item-divider color="medium">{{ typeId === "null" ? translate('Others') : getFacilityGroupTypeDesc(typeId) }}</ion-item-divider>
           <ion-item v-for="group in groups" :key="group.facilityGroupId">
             <ion-checkbox :checked="isFacilityGroupLinked(group.facilityGroupId)" @ion-change="updateGroupsForFacility(group.facilityGroupId)">{{ group.facilityGroupName }}</ion-checkbox>
           </ion-item>

--- a/src/components/AddFacilityGroupModal.vue
+++ b/src/components/AddFacilityGroupModal.vue
@@ -16,7 +16,7 @@
     <form @keyup.enter="updateGroups">
       <ion-list>
         <ion-item-group v-for="(groups, typeId) in filteredFacilityGroupsByType" :key="typeId">
-          <ion-item-divider color="medium">{{ typeId === "null" ? translate('Others') : getFacilityGroupTypeDesc(typeId) }}</ion-item-divider>
+          <ion-item-divider color="medium">{{ getFacilityGroupTypeDesc(typeId) }}</ion-item-divider>
           <ion-item v-for="group in groups" :key="group.facilityGroupId">
             <ion-checkbox :checked="isFacilityGroupLinked(group.facilityGroupId)" @ion-change="updateGroupsForFacility(group.facilityGroupId)">{{ group.facilityGroupName }}</ion-checkbox>
           </ion-item>
@@ -210,12 +210,13 @@ export default defineComponent({
 
         if(!hasError(resp) && resp.data?.docs?.length > 0) {
           this.filteredFacilityGroupsByType = this.facilityGroupsByType = resp.data.docs.reduce((groupsByType: any, group: any) => {
-            if(groupsByType[group.facilityGroupTypeId]) {
-              groupsByType[group.facilityGroupTypeId].push(group)
-            } else {
-              groupsByType[group.facilityGroupTypeId] = [group]
-            }
+            const groupTypeId = !group.facilityGroupTypeId ? "Others" : group.facilityGroupTypeId;
 
+            if(groupsByType[groupTypeId]) {
+              groupsByType[groupTypeId].push(group)
+            } else {
+              groupsByType[groupTypeId] = [group]
+            }
             return groupsByType
           }, {})
         } else {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#258 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, the group type in the modal was shown as 'null' for facility groups not linked to any specific type.
- This has been changed to 'Others' in the modal for groups with a null facilityGroupTypeId.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)