### PR TITLE
Fixed: Zip codes starting with 0 now generate the latitude and longitude correctly(#320)

### DIFF
--- a/src/components/FacilityGeoPointModal.vue
+++ b/src/components/FacilityGeoPointModal.vue
@@ -102,6 +102,7 @@ export default defineComponent({
       this.isGeneratingLatLong = true
       const postalCode = this.geoPoint.postalCode;
       const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : postalCode;
+      
       const payload = {
         json: {
           params: {

--- a/src/components/FacilityGeoPointModal.vue
+++ b/src/components/FacilityGeoPointModal.vue
@@ -100,10 +100,12 @@ export default defineComponent({
     },
     async generateLatLong() {
       this.isGeneratingLatLong = true
+      const postalCode = this.geoPoint.postalCode;
+      const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : `${postalCode}`;
       const payload = {
         json: {
           params: {
-            q: `postcode: ${this.geoPoint.postalCode}`
+            q: `postcode: ${query}`
           }
         }
       }
@@ -113,8 +115,12 @@ export default defineComponent({
 
         if(!hasError(resp) && resp.data.response.docs.length > 0) {
           const result = resp.data.response.docs[0]
-          this.geoPoint.latitude = result.latitude
-          this.geoPoint.longitude = result.longitude
+
+          if (postalCode.startsWith('0') && result.postcode !== postalCode.substring(1)) {
+            throw new Error();
+          }
+          this.geoPoint.latitude = result.latitude;
+          this.geoPoint.longitude = result.longitude;
         } else {
           throw resp.data
         }

--- a/src/components/FacilityGeoPointModal.vue
+++ b/src/components/FacilityGeoPointModal.vue
@@ -115,8 +115,8 @@ export default defineComponent({
 
         if(!hasError(resp) && resp.data.response.docs.length > 0) {
           const result = resp.data.response.docs[0]
-          this.geoPoint.latitude = result.latitude;
-          this.geoPoint.longitude = result.longitude;
+          this.geoPoint.latitude = result.latitude
+          this.geoPoint.longitude = result.longitude
         } else {
           throw resp.data
         }

--- a/src/components/FacilityGeoPointModal.vue
+++ b/src/components/FacilityGeoPointModal.vue
@@ -101,11 +101,11 @@ export default defineComponent({
     async generateLatLong() {
       this.isGeneratingLatLong = true
       const postalCode = this.geoPoint.postalCode;
-      const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : `${postalCode}`;
+      const query = postalCode.startsWith('0') ?  postalCode + ' OR ' + postalCode.substring(1) : postalCode;
       const payload = {
         json: {
           params: {
-            q: `postcode: ${query}`
+            q: 'postcode: ' + query
           }
         }
       }

--- a/src/components/FacilityGeoPointModal.vue
+++ b/src/components/FacilityGeoPointModal.vue
@@ -101,11 +101,11 @@ export default defineComponent({
     async generateLatLong() {
       this.isGeneratingLatLong = true
       const postalCode = this.geoPoint.postalCode;
-      const query = postalCode.startsWith('0') ?  postalCode + ' OR ' + postalCode.substring(1) : postalCode;
+      const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : postalCode;
       const payload = {
         json: {
           params: {
-            q: 'postcode: ' + query
+            q: `postcode: ${query}`
           }
         }
       }
@@ -115,10 +115,6 @@ export default defineComponent({
 
         if(!hasError(resp) && resp.data.response.docs.length > 0) {
           const result = resp.data.response.docs[0]
-
-          if (postalCode.startsWith('0') && result.postcode !== postalCode.substring(1)) {
-            throw new Error();
-          }
           this.geoPoint.latitude = result.latitude;
           this.geoPoint.longitude = result.longitude;
         } else {

--- a/src/components/GeoPointPopover.vue
+++ b/src/components/GeoPointPopover.vue
@@ -48,18 +48,24 @@ export default defineComponent({
       emitter.emit('presentLoader')
 
       try {
+        const postalCode = this.postalAddress.postalCode;
+        const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : postalCode;
+
         resp = await UtilService.generateLatLong({
           json: {
             params: {
-              q: `postcode: ${this.postalAddress.postalCode}`
+              q: `postcode: ${query}`
             }
           }
         })
 
         if(!hasError(resp) && resp.data.response.docs.length > 0) {
           generatedLatLong = resp.data.response.docs[0]
-
           if(generatedLatLong.latitude && generatedLatLong.longitude) {
+            if (postalCode.startsWith('0') && generatedLatLong.postcode !== postalCode.substring(1)) {
+              throw new Error();
+            }
+
             resp = await FacilityService.updateFacilityPostalAddress({
               ...this.postalAddress,
               facilityId: this.facilityId,

--- a/src/components/GeoPointPopover.vue
+++ b/src/components/GeoPointPopover.vue
@@ -49,12 +49,12 @@ export default defineComponent({
 
       try {
         const postalCode = this.postalAddress.postalCode;
-        const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : postalCode;
+        const query = postalCode.startsWith('0') ?  postalCode + ' OR ' + postalCode.substring(1) : postalCode;
 
         resp = await UtilService.generateLatLong({
           json: {
             params: {
-              q: `postcode: ${query}`
+              q: 'postcode: ' + query
             }
           }
         })

--- a/src/components/GeoPointPopover.vue
+++ b/src/components/GeoPointPopover.vue
@@ -49,23 +49,20 @@ export default defineComponent({
 
       try {
         const postalCode = this.postalAddress.postalCode;
-        const query = postalCode.startsWith('0') ?  postalCode + ' OR ' + postalCode.substring(1) : postalCode;
+        const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : postalCode;
 
         resp = await UtilService.generateLatLong({
           json: {
             params: {
-              q: 'postcode: ' + query
+              q: `postcode: ${query}`
             }
           }
         })
 
         if(!hasError(resp) && resp.data.response.docs.length > 0) {
           generatedLatLong = resp.data.response.docs[0]
-          if(generatedLatLong.latitude && generatedLatLong.longitude) {
-            if (postalCode.startsWith('0') && generatedLatLong.postcode !== postalCode.substring(1)) {
-              throw new Error();
-            }
 
+          if(generatedLatLong.latitude && generatedLatLong.longitude) {
             resp = await FacilityService.updateFacilityPostalAddress({
               ...this.postalAddress,
               facilityId: this.facilityId,

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -201,12 +201,12 @@ export default defineComponent({
     },
     async generateLatLong() {
       const postalCode = this.formData.postalCode;
-      const query = postalCode.startsWith('0') ?  postalCode + ' OR ' + postalCode.substring(1) : postalCode;
+      const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : postalCode;
 
       const payload = {
         json: {
           params: {
-            q: 'postcode: ' + query
+            q: `postcode: ${query}`
           }
         }
       }
@@ -214,10 +214,6 @@ export default defineComponent({
         const resp = await UtilService.generateLatLong(payload)
         if (!hasError(resp)) {
           const result = resp.data.response.docs[0]
-
-          if (postalCode.startsWith('0') && result.postcode !== postalCode.substring(1)) {
-            throw new Error();
-          }
           this.formData.latitude = result.latitude
           this.formData.longitude = result.longitude
         } else {

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -201,12 +201,12 @@ export default defineComponent({
     },
     async generateLatLong() {
       const postalCode = this.formData.postalCode;
-      const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : `${postalCode}`;
+      const query = postalCode.startsWith('0') ?  postalCode + ' OR ' + postalCode.substring(1) : postalCode;
 
       const payload = {
         json: {
           params: {
-            q: `postcode: ${query}`
+            q: 'postcode: ' + query
           }
         }
       }

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -200,10 +200,13 @@ export default defineComponent({
       if(this.contactNumber) this.saveTelecomNumber()
     },
     async generateLatLong() {
+      const postalCode = this.formData.postalCode;
+      const query = postalCode.startsWith('0') ? `${postalCode} OR ${postalCode.substring(1)}` : `${postalCode}`;
+
       const payload = {
         json: {
           params: {
-            q: `postcode: ${this.formData.postalCode}`
+            q: `postcode: ${query}`
           }
         }
       }
@@ -211,6 +214,10 @@ export default defineComponent({
         const resp = await UtilService.generateLatLong(payload)
         if (!hasError(resp)) {
           const result = resp.data.response.docs[0]
+
+          if (postalCode.startsWith('0') && result.postcode !== postalCode.substring(1)) {
+            throw new Error();
+          }
           this.formData.latitude = result.latitude
           this.formData.longitude = result.longitude
         } else {

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -1209,7 +1209,9 @@ export default defineComponent({
         const resp = await UtilService.generateLatLong(payload)
 
         if(!hasError(resp)) {
-          this.isRegenerationRequired = !(this.postalAddress.postalCode === resp.data.response.docs[0].postcode)
+          const postalCode = this.postalAddress.postalCode
+          const fetchedPostcode = resp.data.response.docs[0].postcode
+          this.isRegenerationRequired = !(postalCode.startsWith('0') ? postalCode.substring(1) === fetchedPostcode : postalCode === fetchedPostcode);
         } else {
           throw resp.data
         }

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -1211,7 +1211,7 @@ export default defineComponent({
         if(!hasError(resp)) {
           const postalCode = this.postalAddress.postalCode
           const fetchedPostcode = resp.data.response.docs[0].postcode
-          this.isRegenerationRequired = !(postalCode.startsWith('0') ? postalCode.substring(1) === fetchedPostcode : postalCode === fetchedPostcode);
+          this.isRegenerationRequired = !(postalCode.startsWith('0') ? postalCode.substring(1) === fetchedPostcode || postalCode === fetchedPostcode : postalCode === fetchedPostcode);
         } else {
           throw resp.data
         }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#320 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added logic to fetch the latitude and longitude for zip codes starting with 0.
- Added functionality to regenerate the popover when the user edits latitude and longitude from the modal, or when a facility address is added.
- Also added a check on the facility details page to compare the correct zip code based on latitude and longitude.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)