### PR TITLE
Improved: Display Product Store ID instead of Store Name when Store Name is not present.

### DIFF
--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -25,7 +25,7 @@
               <ion-icon :icon="globeOutline" slot="start" />
               <ion-select :label="translate('Product Store')" interface="popover" v-model="query.productStoreId" @ionChange="updateQuery()">
                 <ion-select-option value="">{{ translate("All") }}</ion-select-option>
-                <ion-select-option :value="productStore.productStoreId" :key="index" v-for="(productStore, index) in productStores">{{ productStore.storeName }}</ion-select-option>
+                <ion-select-option :value="productStore.productStoreId" :key="index" v-for="(productStore, index) in productStores">{{ productStore.storeName? productStore.storeName: productStore.productStoreId }}</ion-select-option>
               </ion-select>
             </ion-item>
             <ion-item lines="none">


### PR DESCRIPTION
### Related Issues
#323


### Short Description and Why It's Useful
To improve user experience, we should display the product store ID in place of the store name if the name is not available.



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)