### PR TITLE
Improved archived parking modal on the parking page to only show archived parking (virtual facilities).

### DIFF
--- a/src/components/ArchivedFacilityModal.vue
+++ b/src/components/ArchivedFacilityModal.vue
@@ -21,7 +21,8 @@
         </ion-button>
       </ion-item>
     </ion-list>
-    <ion-infinite-scroll @ionInfinite="ionInfinite">
+    <!-- <ion-infinite-scroll @ionInfinite="loadMoreArchivedFacilities($event)" threshold="100px" :disabled="!isScrollable"> -->
+    <ion-infinite-scroll @ionInfinite="loadMoreArchivedFacilities($event)" threshold="100px">
       <ion-infinite-scroll-content
           loading-spinner="crescent"
           :loading-text="translate('Loading')"
@@ -74,6 +75,7 @@ export default defineComponent({
   computed: {
     ...mapGetters({
       archivedFacilities: 'facility/getArchivedFacilities',
+      isScrollable: 'facility/isArchivedFacilitiesScrollable'
     })
   },
   mounted() {

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -541,7 +541,7 @@ const fetchArchivedFacilities = async (): Promise<any> => {
         distinct: 'Y',
         noConditionFind: 'Y',
         filterByDate: 'Y',
-        viewSize: 50
+        viewSize: 250
       }
     }) as any
 

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -535,7 +535,7 @@ const fetchArchivedFacilities = async (): Promise<any> => {
       data: {
         inputFields: {
           facilityGroupId: 'ARCHIVE',
-          facilityTypeId_value: 'VIRTUAL_FACILITY'
+          facilityTypeId: 'VIRTUAL_FACILITY'
         },
         fieldList: ['facilityName', 'facilityGroupId', 'facilityId', 'facilityGroupTypeId', "fromDate"],
         entityName: "FacilityAndGroupMember",

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -525,7 +525,7 @@ const fetchFacilityGroups = async (payload: any): Promise<any> => {
   })
 }
 
-const fetchArchivedFacilities = async (): Promise<any> => {
+const fetchArchivedFacilities = async (payload :any): Promise<any> => {
   let facilities = []
 
   try {
@@ -542,7 +542,7 @@ const fetchArchivedFacilities = async (): Promise<any> => {
         distinct: 'Y',
         noConditionFind: 'Y',
         filterByDate: 'Y',
-        viewSize: 250
+        ...payload
       }
     }) as any
 

--- a/src/services/FacilityService.ts
+++ b/src/services/FacilityService.ts
@@ -535,6 +535,7 @@ const fetchArchivedFacilities = async (): Promise<any> => {
       data: {
         inputFields: {
           facilityGroupId: 'ARCHIVE',
+          facilityTypeId_value: 'VIRTUAL_FACILITY'
         },
         fieldList: ['facilityName', 'facilityGroupId', 'facilityId', 'facilityGroupTypeId', "fromDate"],
         entityName: "FacilityAndGroupMember",

--- a/src/store/modules/facility/FacilityState.ts
+++ b/src/store/modules/facility/FacilityState.ts
@@ -20,6 +20,9 @@ export default interface FacilityState {
     list: Array<object>,
     total: number
   };
-  archivedFacilities: Array<object>;
+  archivedFacilities: {
+    list: Array<object>,
+    total: number
+  };
   current: any;
 }

--- a/src/store/modules/facility/getters.ts
+++ b/src/store/modules/facility/getters.ts
@@ -13,7 +13,7 @@ const getters: GetterTree <FacilityState, RootState> = {
     return JSON.parse(JSON.stringify(state.facilityGroups.list))
   },
   getArchivedFacilities(state) {
-    return JSON.parse(JSON.stringify(state.archivedFacilities))
+    return JSON.parse(JSON.stringify(state.archivedFacilities.list))
   },
   getFacilityProductStores(state) {
     return state.current.productStores
@@ -53,6 +53,11 @@ const getters: GetterTree <FacilityState, RootState> = {
   },
   getTelecomAndEmailAddress(state) {
     return state.current?.contactDetails
+  },
+  isArchivedFacilitiesScrollable(state) {
+    return (
+      state.archivedFacilities.list?.length > 0 && state.archivedFacilities.list?.length < state.archivedFacilities.total
+    );
   }
 }
 export default getters;

--- a/src/store/modules/facility/index.ts
+++ b/src/store/modules/facility/index.ts
@@ -29,7 +29,10 @@ const facilityModule: Module<FacilityState, RootState> = {
       list: [],
       total: 0
     },
-    archivedFacilities: [],
+    archivedFacilities: {
+      list: [],
+      total: 0
+    },
     current: {}
   },
   getters,

--- a/src/store/modules/facility/mutations.ts
+++ b/src/store/modules/facility/mutations.ts
@@ -55,7 +55,8 @@ const mutations: MutationTree <FacilityState> = {
     state.facilityGroups.total = payload.total
   },
   [types.FACILITY_ARCHIVED_UPDATED](state, payload) {
-    state.archivedFacilities = payload
+    state.archivedFacilities.list = payload.list
+    state.archivedFacilities.total = payload.total
   }
 }
 export default mutations;

--- a/src/views/Parking.vue
+++ b/src/views/Parking.vue
@@ -127,7 +127,6 @@ export default defineComponent({
     })
   },
   async ionViewWillEnter() {
-    await this.fetchArchivedFacilities();
     await this.fetchFacilities();
   },
   methods: {
@@ -204,9 +203,6 @@ export default defineComponent({
       ).then(() => {
         event.target.complete();
       });
-    },
-    async fetchArchivedFacilities() {
-      await this.store.dispatch('facility/fetchArchivedFacilities')
     },
     isFacilityDescriptionAvailable(facility: any) {
       return facility.description && !['BACKORDER', 'PRE_ORDER'].includes(facility.facilityTypeId) && facility.facilityId !== '_NA_';


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#301

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved archived parking modal on the parking page to only show archived parking (virtual facilities) not all archived facilities and also fetch all the archived facilities instead of just 50.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 25-03-25 03:59:05 PM IST.webm](https://github.com/user-attachments/assets/8f1f107e-bbd4-4674-98e3-e2cedcda0afe)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)