### PR TITLE
Implemented: Added a Sell Online popover on the find facilities page(#256)

### DIFF
--- a/src/components/SellOnlineGroupPopover.vue
+++ b/src/components/SellOnlineGroupPopover.vue
@@ -1,7 +1,7 @@
 <template>
   <ion-content>
     <ion-list>
-      <ion-list-header>{{ translate("Sell online") }}</ion-list-header>
+      <ion-list-header>{{ translate("Sell Online") }}</ion-list-header>
       <ion-item v-for="inventoryGroup in current.inventoryGroups" :key="inventoryGroup.facilityGroupId">
         {{ inventoryGroup?.facilityGroupName }}
         <ion-checkbox slot="end" :checked="inventoryGroup.isChecked" @click.prevent="updateSellInventoryOnlineSetting($event, inventoryGroup)" />

--- a/src/components/SellOnlineGroupPopover.vue
+++ b/src/components/SellOnlineGroupPopover.vue
@@ -39,7 +39,8 @@ export default defineComponent({
   },
   computed: {
     ...mapGetters({
-      current: 'facility/getCurrent'
+      current: 'facility/getCurrent',
+      facilities: "facility/getFacilities"
     })
   },
   methods: {
@@ -82,13 +83,16 @@ export default defineComponent({
       emitter.emit("dismissLoader");
 
       // Update the facility list to reflect the change in sell online status
-      const hasAnyChecked = this.current.inventoryGroups.some((group: any) => group.isChecked);
-      this.store.state.facility.facilities.list.map((facility: any) => {
-        if(facility.facilityId === this.current.facilityId && hasAnyChecked !== facility.sellOnline) {
-          facility.sellOnline = hasAnyChecked;
+      const facilities = JSON.parse(JSON.stringify(this.facilities));
+      const isSellOnlineEnabled = this.current.inventoryGroups.some((group: any) => group.isChecked);
+      const updatedFacilities = facilities.map((facility: any) => {
+        if(facility.facilityId === this.current.facilityId) {
+          if(isSellOnlineEnabled !== facility.sellOnline) facility.sellOnline = isSellOnlineEnabled;
+          facility.groupInformation = this.current.groupInformation;
         }
-        facility.groupInformation = this.current.groupInformation;
+        return facility;
       });
+      this.store.dispatch('facility/updateFacilities', updatedFacilities);
     },
   },
   setup() {

--- a/src/components/SellOnlineGroupPopover.vue
+++ b/src/components/SellOnlineGroupPopover.vue
@@ -2,9 +2,9 @@
   <ion-content>
     <ion-list>
       <ion-list-header>{{ translate("Sell Online") }}</ion-list-header>
-      <ion-item v-for="inventoryGroup in current.inventoryGroups" :key="inventoryGroup.facilityGroupId">
+      <ion-item v-for="inventoryGroup in getAssociatedInventoryGroups()" :key="inventoryGroup.facilityGroupId">
         <ion-checkbox label-placement="start" :checked="inventoryGroup.isChecked" @click.prevent="updateSellInventoryOnlineSetting($event, inventoryGroup)">
-          {{ inventoryGroup?.facilityGroupName }}
+          {{ inventoryGroup?.facilityGroupName ? inventoryGroup.facilityGroupName : inventoryGroup.facilityGroupId }}
         </ion-checkbox>
       </ion-item>
     </ion-list>
@@ -13,7 +13,7 @@
 
 <script setup lang="ts">
 import { IonCheckbox, IonContent, IonItem, IonList, IonListHeader } from '@ionic/vue';
-import { computed } from "vue"
+import { computed, defineProps } from "vue"
 import { translate } from "@hotwax/dxp-components";
 import { hasError } from "@/adapter";
 import { showToast } from "@/utils";
@@ -23,8 +23,18 @@ import emitter from '@/event-bus'
 import store from "@/store";
 import { FacilityService } from "@/services/FacilityService";
 
+const props = defineProps(["facility"]);
+
 const current = computed(() => store.getters["facility/getCurrent"]);
 const facilities = computed(() => store.getters["facility/getFacilities"]);
+const inventoryGroups = computed(() => store.getters['util/getInventoryGroups'])
+
+function getAssociatedInventoryGroups() {
+  inventoryGroups.value.forEach((group: any) => {
+    group.isChecked = (props.facility.groupInformation?.some((facilityGroup: any) => facilityGroup?.facilityGroupId === group.facilityGroupId));
+  });
+  return inventoryGroups.value;
+}
 
 async function updateSellInventoryOnlineSetting(event: any, facilityGroup: any) {
   event.stopImmediatePropagation();

--- a/src/components/SellOnlineGroupPopover.vue
+++ b/src/components/SellOnlineGroupPopover.vue
@@ -1,0 +1,103 @@
+<template>
+  <ion-content>
+    <ion-list>
+      <ion-list-header>{{ translate("Sell online") }}</ion-list-header>
+      <ion-item v-for="inventoryGroup in current.inventoryGroups" :key="inventoryGroup.facilityGroupId">
+        {{ inventoryGroup?.facilityGroupName }}
+        <ion-checkbox slot="end" :checked="inventoryGroup.isChecked" @click.prevent="updateSellInventoryOnlineSetting($event, inventoryGroup)" />
+      </ion-item>
+    </ion-list>
+  </ion-content>
+</template>
+
+<script lang="ts">
+import {
+  IonCheckbox,
+  IonContent,
+  IonItem,
+  IonList,
+  IonListHeader,
+} from "@ionic/vue";
+import { defineComponent } from "vue";
+import { translate } from "@hotwax/dxp-components";
+import { mapGetters, useStore } from "vuex";
+import { hasError } from "@/adapter";
+import { showToast } from "@/utils";
+import { DateTime } from 'luxon';
+import logger from "@/logger";
+import emitter from '@/event-bus'
+import { FacilityService } from "@/services/FacilityService";
+
+export default defineComponent({
+  name: "SellOnlineGroupPopover",
+  components: {
+    IonCheckbox,
+    IonContent,
+    IonItem,
+    IonList,
+    IonListHeader
+  },
+  computed: {
+    ...mapGetters({
+      current: 'facility/getCurrent'
+    })
+  },
+  methods: {
+    async updateSellInventoryOnlineSetting(event: any, facilityGroup: any) {
+      event.stopImmediatePropagation();
+      emitter.emit("presentLoader");
+
+      // Using `not` as the click event returns the current status of toggle, but on click we want to change the toggle status
+      const isChecked = !event.target.checked;
+
+      try {
+        let resp;
+        let successMessage;
+        if(isChecked) {
+          resp = await FacilityService.addFacilityToGroup({
+            "facilityId": this.current.facilityId,
+            "facilityGroupId": facilityGroup.facilityGroupId
+          });
+          successMessage = translate('is now selling on', { "facilityName": this.current.facilityName, "facilityGroupId": facilityGroup.facilityGroupName });
+        } else {
+          const groupInformation = this.current.groupInformation.find((group: any) => group.facilityGroupId === facilityGroup.facilityGroupId)
+          resp = await FacilityService.updateFacilityToGroup({
+            "facilityId": this.current.facilityId,
+            "facilityGroupId": facilityGroup.facilityGroupId,
+            "fromDate": groupInformation.fromDate,
+            "thruDate": DateTime.now().toMillis()
+          })
+          successMessage = translate('no longer sells on', { "facilityName": this.current.facilityName, "facilityGroupId": facilityGroup.facilityGroupName })
+        }
+        if(!hasError(resp)) {
+          showToast(successMessage)
+          await this.store.dispatch('facility/fetchFacilityAdditionalInformation')
+        } else {
+          throw resp.data
+        }
+      } catch(err) {
+        showToast(translate('Failed to update sell inventory online setting'))
+        logger.error('Failed to update sell inventory online setting', err)
+      }
+      emitter.emit("dismissLoader");
+
+      // Update the facility list to reflect the change in sell online status
+      const hasAnyChecked = this.current.inventoryGroups.some((group: any) => group.isChecked);
+      this.store.state.facilities = this.store.state.facility.facilities.list.map((facility: any) => {
+        if (facility.facilityId === this.current.facilityId && hasAnyChecked !== facility.sellOnline) {
+          facility.sellOnline = hasAnyChecked;
+        }
+        return facility;
+      });
+    },
+  },
+  setup() {
+    const store = useStore();
+
+    return {
+      store,
+      translate
+    };
+  }
+});
+</script>

--- a/src/components/SellOnlineGroupPopover.vue
+++ b/src/components/SellOnlineGroupPopover.vue
@@ -66,7 +66,6 @@ async function updateSellInventoryOnlineSetting(event: any, facilityGroup: any) 
 
   // Update the facility list to reflect the change in sell online status
   const facilitiesList = JSON.parse(JSON.stringify(facilities.value));
-  console.log('current.value :', current.value);
   const isSellOnlineEnabled = current.value.inventoryGroups.some((group: any) => group.isChecked);
   const updatedFacilities = facilitiesList.map((facility: any) => {
     if(facility.facilityId === current.value.facilityId) {

--- a/src/components/SellOnlineGroupPopover.vue
+++ b/src/components/SellOnlineGroupPopover.vue
@@ -83,11 +83,11 @@ export default defineComponent({
 
       // Update the facility list to reflect the change in sell online status
       const hasAnyChecked = this.current.inventoryGroups.some((group: any) => group.isChecked);
-      this.store.state.facilities = this.store.state.facility.facilities.list.map((facility: any) => {
-        if (facility.facilityId === this.current.facilityId && hasAnyChecked !== facility.sellOnline) {
+      this.store.state.facility.facilities.list.map((facility: any) => {
+        if(facility.facilityId === this.current.facilityId && hasAnyChecked !== facility.sellOnline) {
           facility.sellOnline = hasAnyChecked;
         }
-        return facility;
+        facility.groupInformation = this.current.groupInformation;
       });
     },
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -348,7 +348,6 @@
   "Select which channels this facility publishes inventory too.": "Select which channels this facility publishes inventory too.",
   "Select your preferred language.": "Select your preferred language.",
   "Sell Online": "Sell Online",
-  "Sell online": "Sell online",
   "Sell inventory online": "Sell inventory online",
   "Sequence": "Sequence",
   "sequence": "sequence",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -348,6 +348,7 @@
   "Select which channels this facility publishes inventory too.": "Select which channels this facility publishes inventory too.",
   "Select your preferred language.": "Select your preferred language.",
   "Sell Online": "Sell Online",
+  "Sell online": "Sell online",
   "Sell inventory online": "Sell inventory online",
   "Sequence": "Sequence",
   "sequence": "sequence",

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -9,7 +9,7 @@ import * as types from './mutation-types'
 import logger from '@/logger'
 
 const actions: ActionTree<FacilityState, RootState> = {
-  async fetchFacilitiesAdditionalInformation({ commit, state, rootGetters }, payload = { viewIndex: 0 }) {
+  async fetchFacilitiesAdditionalInformation({ commit, state }, payload = { viewIndex: 0 }) {
 
     // getting all the facilties from state
     const cachedFacilities = JSON.parse(JSON.stringify(state.facilities.list)); // maintaining cachedFacilities as to prepare the facilities payload to fetch additional information
@@ -39,7 +39,6 @@ const actions: ActionTree<FacilityState, RootState> = {
       facility.orderCount = facilitiesOrderCount[facility.facilityId] ? facilitiesOrderCount[facility.facilityId] : 0;
 
       const facilityGroupInformation = facilitiesGroupInformation[facility.facilityId]
-      const inventoryGroups = rootGetters['util/getInventoryGroups'];
 
       if(facilityGroupInformation?.length) {
         facility.groupInformation = facilityGroupInformation
@@ -139,8 +138,8 @@ const actions: ActionTree<FacilityState, RootState> = {
     commit(types.FACILITY_LIST_UPDATED, { facilities, total: facilities.length })
   },
 
-  async fetchFacilityAdditionalInformation({ commit, state, rootGetters }, facilityInfo) {
-    const facility = facilityInfo ? facilityInfo : JSON.parse(JSON.stringify(state.current))
+  async fetchFacilityAdditionalInformation({ commit, state, rootGetters }) {
+    const facility = JSON.parse(JSON.stringify(state.current))
     const inventoryGroups = rootGetters['util/getInventoryGroups'];
     
     const [facilityGroupInformation, facilityOrderCount] = await Promise.all([FacilityService.fetchFacilityGroupInformation([facility.facilityId]), FacilityService.fetchFacilitiesOrderCount([facility.facilityId])])

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -9,7 +9,7 @@ import * as types from './mutation-types'
 import logger from '@/logger'
 
 const actions: ActionTree<FacilityState, RootState> = {
-  async fetchFacilitiesAdditionalInformation({ commit, state }, payload = { viewIndex: 0 }) {
+  async fetchFacilitiesAdditionalInformation({ commit, state, rootGetters }, payload = { viewIndex: 0 }) {
 
     // getting all the facilties from state
     const cachedFacilities = JSON.parse(JSON.stringify(state.facilities.list)); // maintaining cachedFacilities as to prepare the facilities payload to fetch additional information
@@ -39,10 +39,11 @@ const actions: ActionTree<FacilityState, RootState> = {
       facility.orderCount = facilitiesOrderCount[facility.facilityId] ? facilitiesOrderCount[facility.facilityId] : 0;
 
       const facilityGroupInformation = facilitiesGroupInformation[facility.facilityId]
+      const inventoryGroups = rootGetters['util/getInventoryGroups'];
 
       if(facilityGroupInformation?.length) {
         facility.groupInformation = facilityGroupInformation
-        facility.sellOnline = (facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === 'FAC_GRP'))
+        facility.sellOnline = inventoryGroups.some((group: any) => facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === group.facilityGroupId));
         facility.useOMSFulfillment = (facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === 'OMS_FULFILLMENT'))
         facility.generateShippingLabel = (facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === 'AUTO_SHIPPING_LABEL'))
         facility.allowPickup = (facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === 'PICKUP'))
@@ -138,8 +139,8 @@ const actions: ActionTree<FacilityState, RootState> = {
     commit(types.FACILITY_LIST_UPDATED, { facilities, total: facilities.length })
   },
 
-  async fetchFacilityAdditionalInformation({ commit, state, rootGetters }) {
-    const facility = JSON.parse(JSON.stringify(state.current))
+  async fetchFacilityAdditionalInformation({ commit, state, rootGetters }, facilityInfo) {  
+    const facility = facilityInfo ? facilityInfo : JSON.parse(JSON.stringify(state.current))
     const inventoryGroups = rootGetters['util/getInventoryGroups'];
     
     const [facilityGroupInformation, facilityOrderCount] = await Promise.all([FacilityService.fetchFacilityGroupInformation([facility.facilityId]), FacilityService.fetchFacilitiesOrderCount([facility.facilityId])])

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -139,7 +139,7 @@ const actions: ActionTree<FacilityState, RootState> = {
     commit(types.FACILITY_LIST_UPDATED, { facilities, total: facilities.length })
   },
 
-  async fetchFacilityAdditionalInformation({ commit, state, rootGetters }, facilityInfo) {  
+  async fetchFacilityAdditionalInformation({ commit, state, rootGetters }, facilityInfo) {
     const facility = facilityInfo ? facilityInfo : JSON.parse(JSON.stringify(state.current))
     const inventoryGroups = rootGetters['util/getInventoryGroups'];
     

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -43,7 +43,7 @@ const actions: ActionTree<FacilityState, RootState> = {
 
       if(facilityGroupInformation?.length) {
         facility.groupInformation = facilityGroupInformation
-        facility.sellOnline = inventoryGroups.some((group: any) => facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === group.facilityGroupId));
+        facility.sellOnline = facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupTypeId === 'CHANNEL_FAC_GROUP');
         facility.useOMSFulfillment = (facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === 'OMS_FULFILLMENT'))
         facility.generateShippingLabel = (facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === 'AUTO_SHIPPING_LABEL'))
         facility.allowPickup = (facilityGroupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupId === 'PICKUP'))

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -175,6 +175,7 @@ import { FacilityService } from '@/services/FacilityService'
 import { showToast } from '@/utils';
 import logger from '@/logger';
 import FacilityFilters from '@/components/FacilityFilters.vue'
+import { DateTime } from 'luxon';
 import SellOnlineGroupPopover from '@/components/SellOnlineGroupPopover.vue'
 
 export default defineComponent({
@@ -215,7 +216,7 @@ export default defineComponent({
       query: "facility/getFacilityQuery",
       isScrollable: "facility/isFacilitiesScrollable",
       facilityTypes: "util/getFacilityTypes",
-      productStores: "util/getProductStores",
+      productStores: "util/getProductStores"
     })
   },
   async mounted() {

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -61,7 +61,7 @@
             </ion-item>
 
             <div class="tablet">
-              <ion-chip outline @click.stop="openSellOnlineChannelListPopover($event, facility)">
+              <ion-chip outline @click.stop="openSellOnlineGroupPopover($event, facility)">
                 <ion-label>{{ translate('Sell Online') }}</ion-label>
                 <ion-icon :icon="shareOutline" :color="facility.sellOnline ? 'primary' : ''"/>
               </ion-chip>
@@ -342,7 +342,7 @@ export default defineComponent({
         logger.error('Failed to find facility groups', err)
       }
     },
-    async openSellOnlineChannelListPopover(ev: Event, facility: any) {
+    async openSellOnlineGroupPopover(ev: Event, facility: any) {
       await this.store.dispatch('facility/fetchFacilityAdditionalInformation', facility)
       const popover = await popoverController.create({
         component: SellOnlineGroupPopover,

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -175,7 +175,6 @@ import { FacilityService } from '@/services/FacilityService'
 import { showToast } from '@/utils';
 import logger from '@/logger';
 import FacilityFilters from '@/components/FacilityFilters.vue'
-import { DateTime } from 'luxon';
 import SellOnlineGroupPopover from '@/components/SellOnlineGroupPopover.vue'
 
 export default defineComponent({

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -342,11 +342,11 @@ export default defineComponent({
       }
     },
     async openSellOnlineGroupPopover(ev: Event, facility: any) {
-      await this.store.dispatch('facility/fetchFacilityAdditionalInformation', facility)
       const popover = await popoverController.create({
         component: SellOnlineGroupPopover,
         event: ev,
         showBackdrop: false,
+        componentProps: { facility: facility }
       });
       popover.present();
     }

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -61,7 +61,7 @@
             </ion-item>
 
             <div class="tablet">
-              <ion-chip outline @click.stop="updateSellOnlineStatus(facility)">
+              <ion-chip outline @click.stop="openSellOnlineChannelListPopover($event, facility)">
                 <ion-label>{{ translate('Sell Online') }}</ion-label>
                 <ion-icon :icon="shareOutline" :color="facility.sellOnline ? 'primary' : ''"/>
               </ion-chip>
@@ -175,7 +175,7 @@ import { FacilityService } from '@/services/FacilityService'
 import { showToast } from '@/utils';
 import logger from '@/logger';
 import FacilityFilters from '@/components/FacilityFilters.vue'
-import { DateTime } from 'luxon';
+import SellOnlineGroupPopover from '@/components/SellOnlineGroupPopover.vue'
 
 export default defineComponent({
   name: 'FindFacilities',
@@ -215,7 +215,7 @@ export default defineComponent({
       query: "facility/getFacilityQuery",
       isScrollable: "facility/isFacilitiesScrollable",
       facilityTypes: "util/getFacilityTypes",
-      productStores: "util/getProductStores"
+      productStores: "util/getProductStores",
     })
   },
   async mounted() {
@@ -227,6 +227,7 @@ export default defineComponent({
     // from the details page and again coming to the list page, the UI does not gets updated when fetching information in
     // the mounted hook
     await this.fetchFacilityGroups();
+    await this.store.dispatch('util/fetchInventoryGroups')
     this.isScrollingEnabled = false;
     if(this.router.currentRoute.value?.query?.productStoreId) {
       this.query.productStoreId = this.router.currentRoute.value.query.productStoreId
@@ -319,44 +320,6 @@ export default defineComponent({
         logger.error('Failed to update facility', err)
       }
     },
-    async updateSellOnlineStatus(facility: any) {
-      try {
-        let resp
-        if (!facility.sellOnline) {
-          resp = await FacilityService.addFacilityToGroup({
-            "facilityId": facility.facilityId,
-            "facilityGroupId": 'FAC_GRP'
-          })
-        } else {
-          const groupInformation = facility.groupInformation.find((group: any) => group.facilityGroupId === 'FAC_GRP')
-          resp = await FacilityService.updateFacilityToGroup({
-            "facilityId": facility.facilityId,
-            "facilityGroupId": 'FAC_GRP',
-            "fromDate": groupInformation.fromDate,
-            "thruDate": DateTime.now().toMillis()
-          })
-        }
-
-        if (!hasError(resp)) {
-          // updating the facilities state instead of refetching
-          const facilityGroupInformation = await FacilityService.fetchFacilityGroupInformation([facility.facilityId]);
-          const updatedFacilities = JSON.parse(JSON.stringify(this.facilities)).map((facilityData: any) => {
-            if (facility.facilityId === facilityData.facilityId) {
-              facilityData.sellOnline = !facility.sellOnline
-              facilityData.groupInformation = facilityGroupInformation[facility.facilityId]
-            }
-            return facilityData
-          })
-          this.store.dispatch('facility/updateFacilities', updatedFacilities)
-          showToast(translate(`Online inventory turned ${facility.sellOnline ? 'off' : 'on'} for`, { facilityName: facility.facilityName }))
-        } else {
-          throw resp.data
-        }
-      } catch (error) {
-        showToast(translate('Failed to update fulfillment setting'))
-        logger.error('Failed to update fulfillment setting', error)
-      }
-    },
     async fetchFacilityGroups() {
       const params = {
         entityName: "FacilityGroup",
@@ -377,6 +340,15 @@ export default defineComponent({
       } catch (err) {
         logger.error('Failed to find facility groups', err)
       }
+    },
+    async openSellOnlineChannelListPopover(ev: Event, facility: any) {
+      await this.store.dispatch('facility/fetchFacilityAdditionalInformation', facility)
+      const popover = await popoverController.create({
+        component: SellOnlineGroupPopover,
+        event: ev,
+        showBackdrop: false,
+      });
+      popover.present();
     }
   },
   setup() {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#256

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added `Sell Online` popover on the facility list pages, which appears when clicking on the `Sell Online` chip.  
- In the popover, users can associate the inventory channel group with the facility using a checkbox.
### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![image](https://github.com/user-attachments/assets/8790e70e-daaa-40a5-82ec-d0ceba30adaa)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)