### PR TITLE
Improved: Handled single Sell Online facility group case and added a common util function (#256)

### DIFF
--- a/src/components/SellOnlineGroupPopover.vue
+++ b/src/components/SellOnlineGroupPopover.vue
@@ -15,18 +15,13 @@
 import { IonCheckbox, IonContent, IonItem, IonList, IonListHeader } from '@ionic/vue';
 import { computed, defineProps, ref } from "vue"
 import { translate } from "@hotwax/dxp-components";
-import { hasError } from "@/adapter";
-import { showToast } from "@/utils";
-import { DateTime } from 'luxon';
-import logger from "@/logger";
+import { updateFacilityGroup } from "@/utils";
 import emitter from '@/event-bus'
 import store from "@/store";
-import { FacilityService } from "@/services/FacilityService";
 
 const props = defineProps(["facility"]);
 let currentFacility = ref(props.facility);
 
-const facilities = computed(() => store.getters["facility/getFacilities"]);
 const inventoryGroups = computed(() => store.getters['util/getInventoryGroups'])
 
 function getAssociatedInventoryGroups() {
@@ -39,51 +34,9 @@ function getAssociatedInventoryGroups() {
 async function updateSellInventoryOnlineSetting(event: any, facilityGroup: any) {
   event.stopImmediatePropagation();
   emitter.emit("presentLoader");
-
   // Using `not` as the click event returns the current status of toggle, but on click we want to change the toggle status
   const isChecked = !event.target.checked;
-
-  try {
-    let resp;
-    let successMessage;
-    if(isChecked) {
-      resp = await FacilityService.addFacilityToGroup({
-        "facilityId": currentFacility.value.facilityId,
-        "facilityGroupId": facilityGroup.facilityGroupId
-      });
-      successMessage = translate('is now selling on', { "facilityName": currentFacility.value.facilityName, "facilityGroupId": facilityGroup.facilityGroupName });
-    } else {
-      const groupInformation = currentFacility.value.groupInformation.find((group: any) => group.facilityGroupId === facilityGroup.facilityGroupId)
-      resp = await FacilityService.updateFacilityToGroup({
-        "facilityId": currentFacility.value.facilityId,
-        "facilityGroupId": facilityGroup.facilityGroupId,
-        "fromDate": groupInformation.fromDate,
-        "thruDate": DateTime.now().toMillis()
-      })
-      successMessage = translate('no longer sells on', { "facilityName": currentFacility.value.facilityName, "facilityGroupId": facilityGroup.facilityGroupName })
-    }
-    if(!hasError(resp)) {
-      showToast(successMessage)
-      const updatedGroupInformation = await FacilityService.fetchFacilityGroupInformation([currentFacility.value.facilityId])
-      currentFacility.value.groupInformation = Object.values(updatedGroupInformation)[0]
-    } else {
-      throw resp.data
-    }
-  } catch(err) {
-    showToast(translate('Failed to update sell inventory online setting'))
-    logger.error('Failed to update sell inventory online setting', err)
-  }
+  await updateFacilityGroup(currentFacility.value, facilityGroup, isChecked);
   emitter.emit("dismissLoader");
-
-  // Update the facility list to reflect the change in sell online status
-  const facilitiesList = JSON.parse(JSON.stringify(facilities.value));
-  const updatedFacilities = facilitiesList.map((facility: any) => {
-    if(facility.facilityId === currentFacility.value.facilityId) {
-      facility.sellOnline = currentFacility.value.groupInformation.some((facilityGroup: any) => facilityGroup.facilityGroupTypeId === 'CHANNEL_FAC_GROUP');
-      facility.groupInformation = currentFacility.value.groupInformation;
-    }
-    return facility;
-  });
-  store.dispatch('facility/updateFacilities', updatedFacilities);
 }
 </script>

--- a/src/views/FindFacilities.vue
+++ b/src/views/FindFacilities.vue
@@ -172,7 +172,7 @@ import { translate } from '@hotwax/dxp-components'
 import OrderLimitPopover from '@/components/OrderLimitPopover.vue'
 import { hasError } from '@/adapter';
 import { FacilityService } from '@/services/FacilityService'
-import { showToast } from '@/utils';
+import { showToast, updateFacilityGroup } from '@/utils';
 import logger from '@/logger';
 import FacilityFilters from '@/components/FacilityFilters.vue'
 import SellOnlineGroupPopover from '@/components/SellOnlineGroupPopover.vue'
@@ -215,7 +215,8 @@ export default defineComponent({
       query: "facility/getFacilityQuery",
       isScrollable: "facility/isFacilitiesScrollable",
       facilityTypes: "util/getFacilityTypes",
-      productStores: "util/getProductStores"
+      productStores: "util/getProductStores",
+      inventoryGroups: "util/getInventoryGroups"
     })
   },
   async mounted() {
@@ -342,13 +343,18 @@ export default defineComponent({
       }
     },
     async openSellOnlineGroupPopover(ev: Event, facility: any) {
-      const popover = await popoverController.create({
-        component: SellOnlineGroupPopover,
-        event: ev,
-        showBackdrop: false,
-        componentProps: { facility: facility }
-      });
-      popover.present();
+      if(this.inventoryGroups.length === 1) {
+        const isGroupAdded = !facility.groupInformation.some((info: any) => info.facilityGroupId === this.inventoryGroups[0].facilityGroupId);
+        await updateFacilityGroup(facility, this.inventoryGroups[0], isGroupAdded);
+      } else {
+        const popover = await popoverController.create({
+          component: SellOnlineGroupPopover,
+          event: ev,
+          showBackdrop: false,
+          componentProps: { facility: facility }
+        });
+        popover.present();
+      }
     }
   },
   setup() {


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#256 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Previously, in the case of a single facility group, the chip was still opening the popover, which was not the expected behavior.  
- So, handled the case by adding `updateFacilityGroup` as a utility function that works for both scenarios: selecting a single facility group via the chip and selecting multiple groups via the popover checkboxes.  
- Adding this utility function reduces redundant code.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)