### PR TITLE
Fixed : Saved facility calendar is not expanding (#333)

### DIFF
--- a/src/components/AddOperatingHoursModal.vue
+++ b/src/components/AddOperatingHoursModal.vue
@@ -10,7 +10,7 @@
     </ion-toolbar>
   </ion-header>
   <ion-content>
-    <ion-accordion-group v-model="selectedCalendarId" >
+    <ion-accordion-group :value="selectedCalendarId">
       <ion-radio-group v-model="selectedCalendarId">
         <ion-accordion v-for="calendar in calendars" :key="calendar.calendarId" :value="calendar.calendarId">
           <ion-item slot="header">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#333

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Fixed Saved facility calendar is not expanding on clicking the calendar item (not the down arrow) a second time.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
https://jam.dev/c/f4cdf8c5-d732-406a-9016-e8171ec088f7

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)