### PR TITLE
Fix: Include closedDate in facility query to correctly reflect toggle state

### DIFF
--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -99,7 +99,7 @@ const actions: ActionTree<FacilityState, RootState> = {
       "distinct": "Y",
       "fromDateName": "facilityGroupFromDate",
       "thruDateName": "facilityGroupThruDate",
-      "fieldList": ['facilityId', 'facilityName', 'facilityTypeId', 'maximumOrderLimit', 'defaultDaysToShip', 'externalId', 'primaryFacilityGroupId', 'parentFacilityTypeId'],
+      "fieldList": ['facilityId', 'facilityName', 'facilityTypeId', 'maximumOrderLimit', 'defaultDaysToShip', 'externalId', 'primaryFacilityGroupId', 'parentFacilityTypeId', 'closedDate'],
       ...payload
     }
 


### PR DESCRIPTION
### Related Issues

#366

### Short Description and Why It's Useful

Added closedDate to the facility query to ensure the "Permanently Closed" toggle reflects the correct state on the Find Facility page. Fixes the issue where the toggle appeared off despite the facility being closed.

**Ref:** https://github.com/hotwax/facilities/issues/366#issuecomment-3409154838