### PR TITLE
Implemented: support to add direction information when updating/adding facility address(#391)

### DIFF
--- a/src/components/FacilityAddressModal.vue
+++ b/src/components/FacilityAddressModal.vue
@@ -27,6 +27,9 @@
         <ion-input :label="translate('Address line 2')" label-placement="floating" v-model="address.address2" />
       </ion-item>
       <ion-item>
+        <ion-input :label="translate('Directions')" label-placement="floating" v-model="address.directions" />
+      </ion-item>
+      <ion-item>
         <ion-input label-placement="floating" v-model="address.city">
           <div slot="label">{{ translate("City") }} <ion-text color="danger">*</ion-text></div>
         </ion-input>

--- a/src/store/modules/facility/actions.ts
+++ b/src/store/modules/facility/actions.ts
@@ -242,7 +242,7 @@ const actions: ActionTree<FacilityState, RootState> = {
       entityName: "FacilityContactDetailByPurpose",
       orderBy: 'fromDate DESC',
       filterByDate: 'Y',
-      fieldList: ['address1', 'address2', 'city', 'contactMechId', 'contactMechTypeId', 'contactNumber', 'countryCode', 'countryGeoId', 'countryGeoName', 'infoString', 'latitude', 'longitude', 'postalCode', 'stateGeoId', 'stateGeoName', 'toName'],
+      fieldList: ['address1', 'address2', 'city', 'contactMechId', 'contactMechTypeId', 'contactNumber', 'countryCode', 'countryGeoId', 'countryGeoName', 'directions', 'infoString', 'latitude', 'longitude', 'postalCode', 'stateGeoId', 'stateGeoName', 'toName'],
       viewSize: 4
     }
 

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -25,6 +25,9 @@
               <ion-input :label="translate('Address line 2')" label-placement="floating" v-model="formData.address2" />
             </ion-item>
             <ion-item>
+              <ion-input :label="translate('Directions')" label-placement="floating" v-model="formData.directions" />
+            </ion-item>
+            <ion-item>
               <ion-input label-placement="floating" v-model="formData.city">
                 <div slot="label">{{ translate('City') }} <ion-text color="danger">*</ion-text></div>
               </ion-input>
@@ -159,6 +162,7 @@ export default defineComponent({
         toName: '',
         address1: '',
         address2: '',
+        directions: '',
         city: '',
         postalCode: '',
         stateProvinceGeoId: '',

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -55,6 +55,7 @@
                     <h3>{{ postalAddress.toName }}</h3>
                     <h3>{{ postalAddress.address1 }}</h3>
                     <h3>{{ postalAddress.address2 }}</h3>
+                    <h3>{{ postalAddress.directions }}</h3>
                     <p class="ion-text-wrap">{{ postalAddress.postalCode ? `${postalAddress.city}, ${postalAddress.postalCode}` : postalAddress.city }}</p>
                     <p class="ion-text-wrap">{{ postalAddress.countryGeoName ? `${postalAddress.stateGeoName}, ${postalAddress.countryGeoName}` : postalAddress.stateGeoName }}</p>
                     <p class="ion-text-wrap" v-if="contactDetails?.telecomNumber">{{ `${contactDetails.telecomNumber?.countryCode}-${contactDetails.telecomNumber?.contactNumber}` }}</p>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#391 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added support to have directions field on the address modal when updating or creating address for a facility
- Displayed the directions information on facility details page

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
After:

- Address update modal

<img width="1572" height="1098" alt="image" src="https://github.com/user-attachments/assets/bc58c05d-b551-4147-be3c-c6f68dbea600" />

- Facility details page

<img width="2160" height="546" alt="image" src="https://github.com/user-attachments/assets/df12b6ec-e9c8-4958-b984-970f832fe9b4" />


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/facilities#contribution-guideline)