### PR TITLE
fix: allow saving optional phone number and improve visibility conditions (#408)

### DIFF
--- a/src/components/FacilityAddressModal.vue
+++ b/src/components/FacilityAddressModal.vue
@@ -56,7 +56,7 @@
       </ion-item-divider>
       <ion-item>
         <ion-input :label="translate('Contact number')" :label-placement="telecomNumberValue?.countryCode ? 'stacked' : 'floating'" v-model="telecomNumberValue.contactNumber">
-          <ion-text slot="start" v-if="telecomNumberValue?.countryCode">{{ telecomNumberValue?.countryCode }}</ion-text>
+          <ion-text slot="start" v-if="telecomNumberValue?.countryCode && telecomNumberValue?.contactNumber">{{ telecomNumberValue?.countryCode }}</ion-text>
         </ion-input>
       </ion-item>
       <ion-item>
@@ -284,7 +284,7 @@ export default defineComponent({
         : true
     },
     isTelecomNumberUpdated() {
-      return this.telecomNumberValue?.contactNumber && JSON.stringify(this.telecomNumberValue.contactNumber) !== JSON.stringify(this.contactDetails?.telecomNumber?.contactNumber)
+      return JSON.stringify(this.telecomNumberValue?.contactNumber) !== JSON.stringify(this.contactDetails?.telecomNumber?.contactNumber)
     },
     isEmailAddressUpdated() {
       return this.emailAddress?.infoString && JSON.stringify(this.emailAddress.infoString) !== JSON.stringify(this.contactDetails?.emailAddress?.infoString);

--- a/src/components/FacilityAddressModal.vue
+++ b/src/components/FacilityAddressModal.vue
@@ -284,7 +284,7 @@ export default defineComponent({
         : true
     },
     isTelecomNumberUpdated() {
-      return JSON.stringify(this.telecomNumberValue?.contactNumber) !== JSON.stringify(this.contactDetails?.telecomNumber?.contactNumber)
+      return !Object.is(this.telecomNumberValue?.contactNumber, this.contactDetails?.telecomNumber?.contactNumber)
     },
     isEmailAddressUpdated() {
       return this.emailAddress?.infoString && JSON.stringify(this.emailAddress.infoString) !== JSON.stringify(this.contactDetails?.emailAddress?.infoString);

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -58,7 +58,7 @@
                     <h3>{{ postalAddress.directions }}</h3>
                     <p class="ion-text-wrap">{{ postalAddress.postalCode ? `${postalAddress.city}, ${postalAddress.postalCode}` : postalAddress.city }}</p>
                     <p class="ion-text-wrap">{{ postalAddress.countryGeoName ? `${postalAddress.stateGeoName}, ${postalAddress.countryGeoName}` : postalAddress.stateGeoName }}</p>
-                    <p class="ion-text-wrap" v-if="contactDetails?.telecomNumber?.contactNumber">{{ `${contactDetails.telecomNumber?.countryCode}-${contactDetails.telecomNumber?.contactNumber}` }}</p>
+                    <p class="ion-text-wrap" v-if="contactDetails?.telecomNumber?.contactNumber">{{ [contactDetails.telecomNumber.countryCode, contactDetails.telecomNumber.contactNumber].filter(Boolean).join('-') }}</p>
                     <p class="ion-text-wrap" v-if="contactDetails?.emailAddress">{{ contactDetails.emailAddress?.infoString }}</p>
                   </ion-label>
                 </ion-item>

--- a/src/views/FacilityDetails.vue
+++ b/src/views/FacilityDetails.vue
@@ -58,7 +58,7 @@
                     <h3>{{ postalAddress.directions }}</h3>
                     <p class="ion-text-wrap">{{ postalAddress.postalCode ? `${postalAddress.city}, ${postalAddress.postalCode}` : postalAddress.city }}</p>
                     <p class="ion-text-wrap">{{ postalAddress.countryGeoName ? `${postalAddress.stateGeoName}, ${postalAddress.countryGeoName}` : postalAddress.stateGeoName }}</p>
-                    <p class="ion-text-wrap" v-if="contactDetails?.telecomNumber">{{ `${contactDetails.telecomNumber?.countryCode}-${contactDetails.telecomNumber?.contactNumber}` }}</p>
+                    <p class="ion-text-wrap" v-if="contactDetails?.telecomNumber?.contactNumber">{{ `${contactDetails.telecomNumber?.countryCode}-${contactDetails.telecomNumber?.contactNumber}` }}</p>
                     <p class="ion-text-wrap" v-if="contactDetails?.emailAddress">{{ contactDetails.emailAddress?.infoString }}</p>
                   </ion-label>
                 </ion-item>


### PR DESCRIPTION
This PR addresses the issue where the user cannot save changes when removing the facility phone number in the Facility Details address modal.

### Changes
1.  **Fix Validation**: Updated `isTelecomNumberUpdated()` in `FacilityAddressModal.vue` to remove a falsy check, allowing empty contact numbers to be detected as valid updates.
2.  **Improve UI Logic**: 
    - Updated `FacilityAddressModal.vue` to hide the country code prefix when the contact number input is empty.
    - Updated `FacilityDetails.vue` to hide the phone line entirely if the contact number is missing.

### Issue
Closes #408

### Verification
Please refer to the issue description for detailed verification steps.