### PR TITLE
Remove DBIC filter from facility country selection

### DIFF
--- a/src/components/FacilityAddressModal.vue
+++ b/src/components/FacilityAddressModal.vue
@@ -222,7 +222,7 @@ export default defineComponent({
       }
 
       try {
-        if(this.contactDetails.telecomNumber?.contactMechId) {
+        if(this.contactDetails?.telecomNumber?.contactMechId) {
           resp = await FacilityService.updateFacilityTelecomNumber({
             ...payload,
             contactMechId: this.contactDetails.telecomNumber.contactMechId,
@@ -249,7 +249,7 @@ export default defineComponent({
       }
 
       try {
-        if(this.contactDetails.emailAddress?.contactMechId) {
+        if(this.contactDetails?.emailAddress?.contactMechId) {
           resp = await FacilityService.updateFacilityEmailAddress({
             ...payload,
             contactMechId: this.emailAddress.contactMechId,

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -247,9 +247,9 @@ const actions: ActionTree<UtilState, RootState> = {
 
     const params = {
       inputFields: {
-        geoIdTo: "DBIC"
+        geoTypeId: "COUNTRY"
       },
-      entityName: 'GeoAssocAndGeoFrom',
+      entityName: 'Geo',
       fieldList: ['geoName', 'geoId', 'geoCode'],
       noConditionFind: 'Y',
       viewSize: 250

--- a/src/views/AddFacilityConfig.vue
+++ b/src/views/AddFacilityConfig.vue
@@ -291,7 +291,7 @@ export default defineComponent({
         }
 
         showToast(translate("Facility configurations created successfully."))
-        this.$router.replace({ path: `/facility-details/${this.facilityId}` })
+        this.router.replace({ path: `/facility-details/${this.facilityId}` })
       } catch (error: any) {
         showToast(error.message)
         logger.error(error.message)

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -64,16 +64,18 @@ import {
   IonText,
   IonTitle,
   IonToolbar,
+  modalController,
 } from "@ionic/vue";
 import { defineComponent } from "vue";
 import { mapGetters, useStore } from "vuex";
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { addOutline } from 'ionicons/icons';
 import { translate } from "@hotwax/dxp-components";
 import { generateInternalId, showToast } from "@/utils";
 import { FacilityService } from "@/services/FacilityService";
 import { hasError } from "@/adapter";
 import logger from "@/logger";
+import FacilityAddressModal from '@/components/FacilityAddressModal.vue';
 
 export default defineComponent({
   name: "CreateFacility",
@@ -125,7 +127,7 @@ export default defineComponent({
         facilityTypeId_op: 'notEqual'
       })
     ])
-    this.facilityTypesByParentTypeId = this.getFacilityTypesByParentTypeId(this.$route.query.type as string)
+    this.facilityTypesByParentTypeId = this.getFacilityTypesByParentTypeId(this.route.query.type as string)
 
     // In accordance with the specified requirements, it is essential to treat RETAIL STORE and WAREHOUSE
     // as default elements within the list. These elements may appear at any index within the list structure.
@@ -174,8 +176,10 @@ export default defineComponent({
         if (!hasError(resp)) {
           const { facilityId } = resp.data
           showToast(translate("Facility created successfully."))
-          this.store.dispatch('facility/updateCurrentFacility', payload),
-          this.router.replace(`/add-facility-address/${facilityId}`)
+          await this.store.dispatch('facility/updateCurrentFacility', payload)
+          await this.createDefaultFacilityLocation(facilityId)
+          await this.openAddressModal(facilityId, payload.facilityName)
+          this.router.replace(`/add-facility-config/${facilityId}`)
         } else {
           throw resp.data;
         }
@@ -189,9 +193,10 @@ export default defineComponent({
         return;
       }
 
-      // creating default facility location
+    },
+    async createDefaultFacilityLocation(facilityId: string) {
       await FacilityService.createFacilityLocation({
-        facilityId: this.formData.facilityId,
+        facilityId,
         locationTypeEnumId: "FLT_PICKLOC",
         areaId: "TL",
         aisleId: "TL",
@@ -199,6 +204,18 @@ export default defineComponent({
         levelId: "LL",
         positionId: "01",
       })
+    },
+    async openAddressModal(facilityId: string, facilityName: string) {
+      const addressModal = await modalController.create({
+        component: FacilityAddressModal,
+        componentProps: {
+          facilityId,
+          facilityName
+        }
+      })
+
+      addressModal.present()
+      await addressModal.onDidDismiss()
     },
     getFacilityTypesByParentTypeId(parentTypeId: string) {
       return parentTypeId ? Object.keys(this.facilityTypes).reduce((facilityTypesByParentTypeId: any, facilityTypeId: string) => {
@@ -226,10 +243,12 @@ export default defineComponent({
   },
   setup() {
     const store = useStore();
+    const route = useRoute();
     const router = useRouter();
 
     return {
       addOutline,
+      route,
       store,
       router,
       translate


### PR DESCRIPTION
## Summary
- remove the DBIC geo-group filter from facility country loading
- open the existing address/contact modal immediately after creating a facility
- route directly to facility configuration after the address modal closes
- clean up router references that blocked the production build

## Verification
- npm run build

Closes #416